### PR TITLE
Initial cut at a lister retriever implementation.

### DIFF
--- a/src/com/google/enterprise/adaptor/filenet/FileNetAdaptor.java
+++ b/src/com/google/enterprise/adaptor/filenet/FileNetAdaptor.java
@@ -14,6 +14,13 @@
 
 package com.google.enterprise.adaptor.filenet;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.enterprise.adaptor.DocIdPusher.Record;
+import static com.google.enterprise.adaptor.IOHelper.copyStream;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Locale.US;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.enterprise.adaptor.AbstractAdaptor;
 import com.google.enterprise.adaptor.AdaptorContext;
@@ -25,7 +32,16 @@ import com.google.enterprise.adaptor.Response;
 import com.google.enterprise.adaptor.StartupException;
 
 import com.filenet.api.exception.EngineRuntimeException;
+import com.filenet.api.util.Id;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.text.MessageFormat;
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -41,6 +57,7 @@ public class FileNetAdaptor extends AbstractAdaptor {
   private String username;
   private String password;
   private String objectStore;
+  private Traverser documentTraverser;
 
   public static void main(String[] args) {
     AbstractAdaptor.main(new FileNetAdaptor(new FileNetObjectFactory()), args);
@@ -83,6 +100,9 @@ public class FileNetAdaptor extends AbstractAdaptor {
       throw new StartupException(
           "Failed to access content engine's object store", e);
     }
+
+    int maxFeedUrls = Integer.parseInt(config.getValue("feed.maxUrls"));
+    documentTraverser = new MockTraverser(context.getDocIdPusher(), maxFeedUrls);
   }
 
   @VisibleForTesting
@@ -91,11 +111,178 @@ public class FileNetAdaptor extends AbstractAdaptor {
         context.getSensitiveValueDecoder().decodeValue(password));
   }
 
-  @Override
-  public void getDocIds(DocIdPusher pusher) {
+  private static DocId newDocId(Checkpoint checkpoint) {
+    return new DocId("pseudo/" + checkpoint);
+  }
+
+  private static DocId newDocId(Id id) {
+    return new DocId("guid/" + id);
   }
 
   @Override
-  public void getDocContent(Request req, Response resp) {
+  public void getDocIds(DocIdPusher pusher) throws IOException,
+      InterruptedException {
+    pusher.pushRecords(Arrays.asList(
+        new Record.Builder(newDocId(new Checkpoint("type=document")))
+            .setCrawlImmediately(true).build()));
+  }
+
+  @Override
+  public void getDocContent(Request req, Response resp) throws IOException,
+      InterruptedException {
+    DocId id = req.getDocId();
+    String[] idParts = id.getUniqueId().split("/", 2);
+    if (idParts.length != 2) {
+      logger.log(Level.FINE, "Invalid DocId: {0}", id);
+      resp.respondNotFound();
+      return;
+    }
+    switch (idParts[0]) {
+      case "pseudo":
+        Checkpoint checkpoint = new Checkpoint(idParts[1]);
+        switch (checkpoint.traverser) {
+          case "document":
+            documentTraverser.getDocIds(checkpoint);
+            break;
+          default:
+            logger.log(Level.WARNING, "Unsupported traverser: " + checkpoint);
+            break;
+        }
+        break;
+      case "guid":
+        documentTraverser.getDocContent(new Id(idParts[1]), resp);
+        break;
+      default:
+        logger.log(Level.FINE, "Invalid DocId: {0}", id);
+        resp.respondNotFound();
+        return;
+    }
+  }
+
+  @VisibleForTesting
+  static interface Traverser {
+    void getDocIds(Checkpoint checkpoint)
+        throws IOException, InterruptedException;
+
+    void getDocContent(Id id, Response response)
+        throws IOException, InterruptedException;
+  }
+
+  @VisibleForTesting
+  static class MockTraverser implements Traverser {
+    private final String idFormat = "{AAAAAAAA-0000-0000-0000-%012d}";
+    private final DocIdPusher pusher;
+    private final int maxFeedUrls;
+
+    MockTraverser(DocIdPusher pusher, int maxFeedUrls) {
+      this.pusher = checkNotNull(pusher, "pusher must not be null");
+      checkArgument(maxFeedUrls > 2, "feed.maxUrls must be greater than 2");
+      this.maxFeedUrls = maxFeedUrls;
+    }
+
+    @Override
+    public void getDocIds(Checkpoint checkpoint)
+        throws IOException, InterruptedException {
+      Date timestamp;
+      int id;
+      if (checkpoint.uuid == null) {
+        timestamp = new Date();
+        id = 0;
+      } else {
+        timestamp = checkpoint.timestamp;
+        String idStr = checkpoint.uuid.toString();
+        id = Integer.parseInt(
+            idStr.substring(idStr.lastIndexOf('-') + 1, idStr.length() - 1));
+      }
+      int maxDocIds = maxFeedUrls - 1;
+      List<Record> records = new ArrayList<>(maxDocIds);
+      for (int i = 0; i < maxDocIds && id < 10000; i++, id++) {
+        DocId docid = newDocId(new Id(String.format(idFormat, id)));
+        records.add(new Record.Builder(docid).build());
+      }
+      Checkpoint newCheckpoint;
+      if (records.isEmpty()) {
+        // No new data, push old checkpoint;
+        newCheckpoint = checkpoint;
+      } else {
+        newCheckpoint = new Checkpoint(checkpoint.traverser, timestamp,
+            new Id(String.format(idFormat, id)));
+      }
+      records.add(new Record.Builder(newDocId(newCheckpoint))
+          .setCrawlImmediately(true)
+          //.setLastModified(new Date()) TODO(bmj)
+          .build());
+      pusher.pushRecords(records);
+    }
+
+    @Override
+    public void getDocContent(Id id, Response response) throws IOException {
+      checkNotNull(id, "id must not be null");
+      checkNotNull(response, "response must not be null");
+      String content = "Hello from document " + id;
+      response.setContentType("text/plain");
+      copyStream(new ByteArrayInputStream(content.getBytes(UTF_8)),
+                 response.getOutputStream());
+    }
+  }
+
+  @VisibleForTesting
+  static class Checkpoint {
+    private static final MessageFormat SHORT_FORMAT = new MessageFormat(
+        "type={0}", US);
+    private static final MessageFormat FULL_FORMAT = new MessageFormat(
+        "type={0};timestamp={1,date,yyyy-MM-dd'T'HH:mm:ss.SSSZ};guid={2}", US);
+
+    public String traverser;
+    public Date timestamp;
+    public Id uuid;
+
+    @SuppressWarnings("fallthrough")
+    public Checkpoint(String checkpoint) {
+      checkNotNull(checkpoint, "checkpoint may not be null");
+      logger.info("Checkpoint: '" + checkpoint + "'");
+      Object[] objs;
+      try {
+        if (checkpoint.indexOf(';') < 0) {
+          objs = SHORT_FORMAT.parse(checkpoint);
+        } else {
+          objs = FULL_FORMAT.parse(checkpoint);
+        }
+      } catch (ParseException e) {
+        throw new IllegalArgumentException(
+            "Invalid Checkpoint: " + checkpoint, e);
+      }
+      switch (objs.length) {
+        case 3:
+          timestamp = (Date) objs[1];
+          logger.info("timestamp: " + timestamp.toString());
+          uuid = new Id((String) objs[2]);
+          logger.info("guid: " + timestamp.toString());
+          // fall through
+        case 1:
+          traverser = (String) objs[0];
+          logger.info("traverser: " + traverser);
+          break;
+        default:
+          throw new IllegalArgumentException(
+              "Invalid Checkpoint: " + checkpoint);
+      }
+    }
+
+    public Checkpoint(String traverser, Date timestamp, Id uuid) {
+      this.traverser = checkNotNull(traverser, "traverser may not be null");
+      this.timestamp = timestamp;
+      this.uuid = uuid;
+    }
+
+    @Override
+    public String toString() {
+      if (timestamp == null && uuid == null) {
+        return SHORT_FORMAT.format(new Object[] {traverser});
+      } else {
+        return FULL_FORMAT.format(
+            new Object[] {traverser, timestamp, uuid.toString()});
+      }
+    }
   }
 }

--- a/test/com/google/enterprise/adaptor/filenet/FileNetAdaptorTest.java
+++ b/test/com/google/enterprise/adaptor/filenet/FileNetAdaptorTest.java
@@ -14,14 +14,24 @@
 
 package com.google.enterprise.adaptor.filenet;
 
+import static com.google.enterprise.adaptor.DocIdPusher.Record;
+import static com.google.enterprise.adaptor.filenet.FileNetAdaptor.Checkpoint;
+import static com.google.enterprise.adaptor.filenet.FileNetAdaptor.MockTraverser;
+import static com.google.enterprise.adaptor.filenet.FileNetAdaptor.Traverser;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.enterprise.adaptor.AdaptorContext;
 import com.google.enterprise.adaptor.Config;
+import com.google.enterprise.adaptor.DocId;
+import com.google.enterprise.adaptor.testing.RecordingDocIdPusher;
+import com.google.enterprise.adaptor.testing.RecordingResponse;
 
+import com.filenet.api.util.Id;
 import com.filenet.api.util.UserContext;
 
 import org.junit.Before;
@@ -29,7 +39,11 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.io.ByteArrayOutputStream;
 import java.security.Principal;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
 import javax.security.auth.Subject;
 
 /** Unit tests for FileNetAdaptor */
@@ -72,5 +86,192 @@ public class FileNetAdaptorTest {
       assertTrue(subject.equals(UserContext.get().getSubject()));
     }
     assertFalse(subject.equals(UserContext.get().getSubject()));
+  }
+
+  @Test
+  public void testCheckpoint_ctor_nullCheckpoint() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("checkpoint may not be null");
+    new Checkpoint(null);
+  }
+
+  @Test
+  public void testCheckpoint_ctor_nullTraverser() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("traverser may not be null");
+    new Checkpoint(null, new Date(),
+        new Id("{AAAAAAAA-0000-0000-0000-000000000000}"));
+  }
+
+  @Test
+  public void testCheckpoint_ctor_invalidCheckpoint() {
+    thrown.expect(IllegalArgumentException.class);
+    new Checkpoint("foo=bar");
+  }
+
+  @Test
+  public void testCheckpoint_ctor_shortCheckpoint() {
+    Checkpoint checkpoint = new Checkpoint("type=document");
+    assertEquals("document", checkpoint.traverser);
+    assertNull(checkpoint.timestamp);
+    assertNull(checkpoint.uuid);
+  }
+
+  @Test
+  public void testCheckpoint_ctor_longCheckpoint() throws Exception {
+    SimpleDateFormat dateFmt
+        = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+    Date now = new Date();
+
+    Checkpoint checkpoint = new Checkpoint("type=document;timestamp="
+       + dateFmt.format(now)
+       + ";guid={AAAAAAAA-0000-0000-0000-000000000000}");
+    assertEquals("document", checkpoint.traverser);
+    assertEquals(now, checkpoint.timestamp);
+    assertEquals(new Id("{AAAAAAAA-0000-0000-0000-000000000000}"),
+                 checkpoint.uuid);
+  }
+
+  @Test
+  public void testCheckpoint_ctor_threeArgs() throws Exception {
+    SimpleDateFormat dateFmt
+        = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+    Date now = new Date();
+    String traverser = "document";
+    Id id = new Id("{AAAAAAAA-0000-0000-0000-000000000000}");
+
+    Checkpoint checkpoint = new Checkpoint(traverser, now, id);
+    assertEquals(traverser, checkpoint.traverser);
+    assertEquals(now, checkpoint.timestamp);
+    assertEquals(id, checkpoint.uuid);
+  }
+
+  @Test
+  public void testCheckpoint_toString_shortCheckpoint() {
+    String checkpointStr = "type=document";
+    Checkpoint checkpoint = new Checkpoint(checkpointStr);
+    assertEquals(checkpointStr, checkpoint.toString());
+  }
+
+  @Test
+  public void testCheckpoint_toString_longCheckpoint() throws Exception {
+    SimpleDateFormat dateFmt
+        = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+    Date now = new Date();
+    String checkpointStr = "type=document;timestamp=" + dateFmt.format(now)
+       + ";guid={AAAAAAAA-0000-0000-0000-000000000000}";
+    Checkpoint checkpoint = new Checkpoint(checkpointStr);
+    assertEquals(checkpointStr, checkpoint.toString());
+  }
+
+  @Test
+  public void testMockTraverser_ctor_nullPusher() throws Exception {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("pusher must not be null");
+    new MockTraverser(null, 1000);
+  }
+
+  @Test
+  public void testMockTraverser_ctor_maxFeedUrls() throws Exception {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("feed.maxUrls must be greater than 2");
+    new MockTraverser(new RecordingDocIdPusher(), 1);
+  }
+
+  @Test
+  public void testMockTraverser_getDocIds_shortCheckpoint() throws Exception {
+    long startTime = new Date().getTime();
+    RecordingDocIdPusher pusher = new RecordingDocIdPusher();
+    Traverser traverser = new MockTraverser(pusher, 5);
+    traverser.getDocIds(new Checkpoint("type=document"));
+
+    List<Record> golden = ImmutableList.of(
+        new Record.Builder(
+            new DocId("guid/{AAAAAAAA-0000-0000-0000-000000000000}"))
+        .build(),
+        new Record.Builder(
+            new DocId("guid/{AAAAAAAA-0000-0000-0000-000000000001}"))
+        .build(),
+        new Record.Builder(
+            new DocId("guid/{AAAAAAAA-0000-0000-0000-000000000002}"))
+        .build(),
+        new Record.Builder(
+            new DocId("guid/{AAAAAAAA-0000-0000-0000-000000000003}"))
+        .build());
+
+    List<Record> actual = pusher.getRecords();
+    // Assert that the pushed DocIds match.
+    assertEquals(golden, actual.subList(0, actual.size() - 1));
+
+    // Now check the continuation record.
+    Record continuation = actual.get(actual.size() - 1);
+    String docid = continuation.getDocId().getUniqueId();
+    assertTrue(docid, docid.startsWith("pseudo/"));
+    Checkpoint checkpoint
+        = new Checkpoint(docid.substring(docid.indexOf('/') + 1));
+    assertEquals("document", checkpoint.traverser);
+    assertEquals(new Id("{AAAAAAAA-0000-0000-0000-000000000004}"),
+                 checkpoint.uuid);
+    assertTrue((checkpoint.timestamp.getTime() - startTime) < 2000);
+  }
+
+  @Test
+  public void testMockTraverser_getDocIds_longCheckpoint() throws Exception {
+    Date timestamp = new Date();
+    RecordingDocIdPusher pusher = new RecordingDocIdPusher();
+    Traverser traverser = new MockTraverser(pusher, 5);
+    Checkpoint startCheckpoint = new Checkpoint("document", timestamp,
+        new Id("{AAAAAAAA-0000-0000-0000-000000000004}"));
+
+    traverser.getDocIds(startCheckpoint);
+
+    Checkpoint expectedCheckpoint = new Checkpoint("document", timestamp,
+        new Id("{AAAAAAAA-0000-0000-0000-000000000008}"));
+    List<Record> golden = ImmutableList.of(
+        new Record.Builder(
+            new DocId("guid/{AAAAAAAA-0000-0000-0000-000000000004}"))
+        .build(),
+        new Record.Builder(
+            new DocId("guid/{AAAAAAAA-0000-0000-0000-000000000005}"))
+        .build(),
+        new Record.Builder(
+            new DocId("guid/{AAAAAAAA-0000-0000-0000-000000000006}"))
+        .build(),
+        new Record.Builder(
+            new DocId("guid/{AAAAAAAA-0000-0000-0000-000000000007}"))
+        .build(),
+        new Record.Builder(new DocId("pseudo/" + expectedCheckpoint))
+        .setCrawlImmediately(true).build());
+    assertEquals(golden, pusher.getRecords());
+  }
+
+  @Test
+  public void testMockTraverser_getDocIds_endOfTraversal() throws Exception {
+    Date timestamp = new Date();
+    RecordingDocIdPusher pusher = new RecordingDocIdPusher();
+    Traverser traverser = new MockTraverser(pusher, 5);
+    Checkpoint startCheckpoint = new Checkpoint("document", timestamp,
+        new Id("{AAAAAAAA-0000-0000-0000-000000010000}"));
+
+    traverser.getDocIds(startCheckpoint);
+
+    Checkpoint expectedCheckpoint = startCheckpoint;
+    List<Record> golden = ImmutableList.of(
+        new Record.Builder(new DocId("pseudo/" + expectedCheckpoint))
+        .setCrawlImmediately(true).build());
+    assertEquals(golden, pusher.getRecords());
+  }
+
+  @Test
+  public void testMocTraverser_getDocContent() throws Exception {
+    RecordingDocIdPusher pusher = new RecordingDocIdPusher();
+    Traverser traverser = new MockTraverser(pusher, 5);
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    RecordingResponse response = new RecordingResponse(baos);
+    traverser.getDocContent(new Id("{AAAAAAAA-0000-0000-0000-000000000004}"),
+        response);
+    assertEquals("text/plain", response.getContentType());
+    assertEquals("Hello from document {AAAAAAAA-0000-0000-0000-000000000004}",
+                 baos.toString("UTF-8"));
   }
 }

--- a/test/com/google/enterprise/adaptor/filenet/FileNetAdaptorTest.java
+++ b/test/com/google/enterprise/adaptor/filenet/FileNetAdaptorTest.java
@@ -179,11 +179,28 @@ public class FileNetAdaptorTest {
   }
 
   @Test
-  public void testMockTraverser_getDocIds_shortCheckpoint() throws Exception {
+  public void testGetDocIds() throws Exception {
     long startTime = new Date().getTime();
-    RecordingDocIdPusher pusher = new RecordingDocIdPusher();
-    Traverser traverser = new MockTraverser(pusher, 5);
-    traverser.getDocIds(new Checkpoint("type=document"));
+    RecordingDocIdPusher pusher
+        = (RecordingDocIdPusher) context.getDocIdPusher();
+    config.overrideKey("feed.maxUrls", "5");
+    adaptor.init(context);
+    adaptor.getDocIds(pusher);
+
+    List<Record> golden = ImmutableList.of(
+        new Record.Builder(new DocId("pseudo/document"))
+        .setCrawlImmediately(true).build());
+    assertEquals(golden, pusher.getRecords());
+  }
+
+  @Test
+  public void testGetDocContent_shortCheckpoint() throws Exception {
+    long startTime = new Date().getTime();
+    RecordingDocIdPusher pusher
+        = (RecordingDocIdPusher) context.getDocIdPusher();
+    config.overrideKey("feed.maxUrls", "5");
+    adaptor.init(context);
+    adaptor.getDocIds(pusher);
 
     List<Record> golden = ImmutableList.of(
         new Record.Builder(
@@ -216,7 +233,7 @@ public class FileNetAdaptorTest {
   }
 
   @Test
-  public void testMockTraverser_getDocIds_longCheckpoint() throws Exception {
+  public void testGetDocContent_longCheckpoint() throws Exception {
     Date timestamp = new Date();
     RecordingDocIdPusher pusher = new RecordingDocIdPusher();
     Traverser traverser = new MockTraverser(pusher, 5);
@@ -246,7 +263,7 @@ public class FileNetAdaptorTest {
   }
 
   @Test
-  public void testMockTraverser_getDocIds_endOfTraversal() throws Exception {
+  public void testGetDocContent_endOfTraversal() throws Exception {
     Date timestamp = new Date();
     RecordingDocIdPusher pusher = new RecordingDocIdPusher();
     Traverser traverser = new MockTraverser(pusher, 5);

--- a/test/com/google/enterprise/adaptor/filenet/Logging.java
+++ b/test/com/google/enterprise/adaptor/filenet/Logging.java
@@ -1,0 +1,53 @@
+// Copyright 2014 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.enterprise.adaptor.filenet;
+
+import java.util.Collection;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+/** Tools to test logging output. */
+public class Logging {
+  /**
+   * Enables logging and captures matching log messages. The messages
+   * will not be localized or formatted.
+   *
+   * @param clazz the class to enable logging for
+   * @param substring capture log messages containing this substring
+   * @param output captured messages will be added to this collection
+   */
+  public static void captureLogMessages(Class<?> clazz,
+      final String substring, final Collection<? super String> output) {
+    Logger logger = Logger.getLogger(clazz.getName());
+    logger.setLevel(Level.ALL);
+
+    logger.addHandler(new Handler() {
+        @Override public void close() {}
+        @Override public void flush() {}
+
+        @Override public void publish(LogRecord record) {
+          if (record.getMessage().contains(substring)) {
+            output.add(record.getMessage());
+          }
+        }
+      });
+  }
+
+  private Logging() {
+    throw new AssertionError();
+  }
+}

--- a/test/com/google/enterprise/adaptor/filenet/MockRequest.java
+++ b/test/com/google/enterprise/adaptor/filenet/MockRequest.java
@@ -1,0 +1,57 @@
+// Copyright 2014 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.enterprise.adaptor.filenet;
+
+import com.google.enterprise.adaptor.DocId;
+import com.google.enterprise.adaptor.Request;
+
+import java.util.Date;
+
+/** A trivial implemenation of {@link Request} */
+// Copied from the Filesystem Adaptor
+class MockRequest implements Request {
+  private final DocId docid;
+  private final Date lastAccess;
+
+  MockRequest(DocId docid) {
+    this(docid, null);
+  }
+
+  MockRequest(DocId docid, Date lastAccess) {
+    this.docid = docid;
+    this.lastAccess = lastAccess;
+  }
+
+  @Override
+  public boolean hasChangedSinceLastAccess(Date lastModified) {
+    return (lastAccess == null || lastModified == null) ? true
+        : lastModified.after(lastAccess);
+  }
+
+  @Override
+  public Date getLastAccessTime() {
+    return lastAccess;
+  }
+
+  @Override
+  public DocId getDocId() {
+    return docid;
+  }
+
+  @Override
+  public boolean canRespondWithNoContent(Date lastModified) {
+    return !hasChangedSinceLastAccess(lastModified);
+  }
+}

--- a/test/com/google/enterprise/adaptor/filenet/ProxyAdaptorContext.java
+++ b/test/com/google/enterprise/adaptor/filenet/ProxyAdaptorContext.java
@@ -18,8 +18,10 @@ import com.google.enterprise.adaptor.AdaptorContext;
 import com.google.enterprise.adaptor.Config;
 import com.google.enterprise.adaptor.DocId;
 import com.google.enterprise.adaptor.DocIdEncoder;
+import com.google.enterprise.adaptor.DocIdPusher;
 import com.google.enterprise.adaptor.PollingIncrementalLister;
 import com.google.enterprise.adaptor.SensitiveValueDecoder;
+import com.google.enterprise.adaptor.testing.RecordingDocIdPusher;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -35,9 +37,14 @@ class ProxyAdaptorContext {
     private final DocIdEncoder docIdEncoder = new MockDocIdCodec();
     private final SensitiveValueDecoder sensitiveValueDecoder =
         new MockSensitiveValueDecoder();
+    private final RecordingDocIdPusher pusher = new RecordingDocIdPusher();
 
     public Config getConfig() {
       return config;
+    }
+
+    public DocIdPusher getDocIdPusher() {
+      return pusher;
     }
 
     public DocIdEncoder getDocIdEncoder() {


### PR DESCRIPTION
- Implements Adaptor.getDocIds(), Adaptor.getDocContent().
- Defines a rudimentary Traversal Interface.
- Implements a MockTraverser that lists fake DocIds and returns simple content.
- Implements a Checkpoint class.
- Adds unit tests.
- Imports MockRequest and Logging test classes from database adaptor.
