### PR TITLE
Remove IDocument and its implementations, part 1.

### DIFF
--- a/src/com/google/enterprise/adaptor/filenet/FnDocument.java
+++ b/src/com/google/enterprise/adaptor/filenet/FnDocument.java
@@ -14,76 +14,25 @@
 
 package com.google.enterprise.adaptor.filenet;
 
-import com.google.common.annotations.VisibleForTesting;
-
 import com.filenet.api.collection.AccessPermissionList;
 import com.filenet.api.collection.ActiveMarkingList;
-import com.filenet.api.collection.BooleanList;
-import com.filenet.api.collection.DateTimeList;
-import com.filenet.api.collection.Float64List;
-import com.filenet.api.collection.IdList;
-import com.filenet.api.collection.Integer32List;
-import com.filenet.api.collection.StringList;
-import com.filenet.api.core.ContentTransfer;
 import com.filenet.api.core.Document;
 import com.filenet.api.core.Folder;
 import com.filenet.api.core.VersionSeries;
-import com.filenet.api.exception.EngineRuntimeException;
-import com.filenet.api.exception.ExceptionCode;
-import com.filenet.api.property.Properties;
-import com.filenet.api.property.Property;
-import com.filenet.api.property.PropertyBinary;
-import com.filenet.api.property.PropertyBinaryList;
-import com.filenet.api.property.PropertyBoolean;
-import com.filenet.api.property.PropertyBooleanList;
-import com.filenet.api.property.PropertyDateTime;
-import com.filenet.api.property.PropertyDateTimeList;
-import com.filenet.api.property.PropertyFloat64;
-import com.filenet.api.property.PropertyFloat64List;
-import com.filenet.api.property.PropertyId;
-import com.filenet.api.property.PropertyIdList;
-import com.filenet.api.property.PropertyInteger32;
-import com.filenet.api.property.PropertyInteger32List;
-import com.filenet.api.property.PropertyString;
-import com.filenet.api.property.PropertyStringList;
 import com.filenet.api.util.Id;
 
 import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.Date;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * Core document class, which directly interacts with the core FileNet APIs
  * related to Documents.
  */
-public class FnDocument implements IDocument {
-  private static final Logger logger =
-      Logger.getLogger(FnDocument.class.getName());
-
+class FnDocument implements IDocument {
   private final Document doc;
-  private final Map<String, Property> metas;
 
   public FnDocument(Document doc) {
     this.doc = doc;
-    this.metas = getMetas();
-  }
-
-  private Map<String, Property> getMetas() {
-    Map<String, Property> propMap = new HashMap<>();
-    Properties props = doc.getProperties();
-    Property[] propList = props.toArray();
-    for (Property property : propList) {
-      propMap.put(property.getPropertyName(), property);
-    }
-    return propMap;
   }
 
   @Override
@@ -107,17 +56,8 @@ public class FnDocument implements IDocument {
   }
 
   @Override
-  public InputStream getContent() {
-    InputStream ip = null;
-    try {
-      List<?> contentList = doc.get_ContentElements();
-      ContentTransfer content = (ContentTransfer) contentList.get(0);
-      ip = content.accessContentStream();
-    } catch (Exception er) {
-      logger.log(Level.WARNING, "Unable to retrieve the content of file for "
-          + this.doc.get_Id() + " " + er.getLocalizedMessage(), er);
-    }
-    return ip;
+  public InputStream accessContentStream(int index) {
+    return doc.accessContentStream(index);
   }
 
   @Override
@@ -135,331 +75,18 @@ public class FnDocument implements IDocument {
     return doc.get_VersionSeries();
   }
 
-  @SuppressWarnings({"rawtypes", "unchecked"})
-  private static class EmptyActiveMarkingList extends ArrayList
-    implements ActiveMarkingList {}
-
   @Override
   public ActiveMarkingList get_ActiveMarkings() {
-    try {
-      return doc.get_ActiveMarkings();
-    } catch (EngineRuntimeException e) {
-      if (e.getExceptionCode() == ExceptionCode.API_PROPERTY_NOT_IN_CACHE) {
-        logger.log(Level.FINER, e.getMessage());
-        return new EmptyActiveMarkingList();
-      } else {
-        throw e;
-      }
-    }
+    return doc.get_ActiveMarkings();
   }
 
   @Override
   public Folder get_SecurityFolder() {
-    try {
-      return doc.get_SecurityFolder();
-    } catch (EngineRuntimeException e) {
-      logger.log(Level.WARNING,
-          "Unable to get security folder for document {0}", doc.get_Id());
-      return null;
-    }
+    return doc.get_SecurityFolder();
   }
 
   @Override
-  public Set<String> getPropertyNames() {
-    return metas.keySet();
-  }
-
-  @Override
-  public void getProperty(String name, List<String> list) {
-    Property prop = metas.get(name);
-    if (prop == null) {
-      logger.log(Level.FINEST, "Property not found: {0}", name);
-      return;
-    }
-    if (prop instanceof PropertyString
-        || prop instanceof PropertyStringList) {
-      logger.log(Level.FINEST, "Getting String property: [{0}]", name);
-      getPropertyStringValue(name, list);
-    } else if (prop instanceof PropertyBinary
-        || prop instanceof PropertyBinaryList) {
-      logger.log(Level.FINEST, "Binary property [{0}] is not supported.", name);
-    } else if (prop instanceof PropertyBoolean
-        || prop instanceof PropertyBooleanList) {
-      logger.log(Level.FINEST, "Getting Boolean property: [{0}]", name);
-      getPropertyBooleanValue(name, list);
-    } else if (prop instanceof PropertyDateTime
-        || prop instanceof PropertyDateTimeList) {
-      logger.log(Level.FINEST, "Getting Date property: [{0}]", name);
-      getPropertyDateValue(name, list);
-    } else if (prop instanceof PropertyFloat64
-        || prop instanceof PropertyFloat64List) {
-      logger.log(Level.FINEST, "Getting Double/Float property: [{0}]", name);
-      getPropertyDoubleValue(name, list);
-    } else if (prop instanceof PropertyInteger32
-        || prop instanceof PropertyInteger32List) {
-      logger.log(Level.FINEST, "Getting Integer/Long property: [{0}]", name);
-      getPropertyLongValue(name, list);
-    } else if (prop instanceof PropertyId
-        || prop instanceof PropertyIdList) {
-      logger.log(Level.FINEST, "Getting Id property: [{0}]", name);
-      getPropertyGuidValue(name, list);
-    } else {
-      logger.log(Level.FINEST, "Property type for {0} is not determined: ",
-          prop.getClass().getName());
-    }
-  }
-
-  /**
-   * Fetches the String type metadata from FileNet. Responsible for
-   * distinguishing between single-valued and multi-valued metadata. If the
-   * value fetched from FileNet is of instance type List then it is
-   * multi-valued else it is single-valued.
-   */
-  @Override
-  public void getPropertyStringValue(String propertyName,
-      List<String> valuesList) {
-    Property prop = metas.get(propertyName);
-    if (prop == null) {
-      logger.log(Level.FINEST, "{0} property is null", propertyName);
-      return;
-    }
-    if (prop instanceof PropertyString) {
-      String val = prop.getStringValue();
-      if (val != null) {
-        valuesList.add(val.toString());
-      } else {
-        logger.log(Level.FINEST,
-            "{0} property [PropertyString] contains NULL value", propertyName);
-      }
-    } else if (prop instanceof PropertyStringList) {
-      StringList slist = prop.getStringListValue();
-      Iterator<?> iter = slist.iterator();
-      while (iter.hasNext()) {
-        String val = (String) iter.next();
-        if (val != null) {
-          valuesList.add(val.toString());
-        } else {
-          logger.log(Level.FINEST,
-              "{0} property [PropertyStringList] contains NULL value",
-              propertyName);
-        }
-      }
-    } else {
-      throw new /*TODO*/ RuntimeException("Invalid data type: "
-          + propertyName + " property is not a String type");
-    }
-  }
-
-  /**
-   * Fetches the GUID type metadata from FileNet. Responsible for
-   * distinguishing between single-valued and multi-valued metadata. If the
-   * value fetched from FileNet is of instance type List then it is
-   * multi-valued else it is single-valued.
-   */
-  @VisibleForTesting
-  void getPropertyGuidValue(String propertyName, List<String> valuesList) {
-    Property prop = metas.get(propertyName);
-    if (prop == null) {
-      logger.log(Level.FINEST, "{0} property is null", propertyName);
-      return;
-    }
-    if (prop instanceof PropertyId) {
-      Id val = prop.getIdValue();
-      if (val != null) {
-        String id = val.toString();
-        valuesList.add(id.substring(1, id.length() - 1));
-      } else {
-        logger.log(Level.FINEST,
-            "{0} property [PropertyId] contains NULL value", propertyName);
-      }
-    } else if (prop instanceof PropertyIdList) {
-      IdList idList = prop.getIdListValue();
-      Iterator<?> iter = idList.iterator();
-      while (iter.hasNext()) {
-        Id val = (Id) iter.next();
-        if (val != null) {
-          // Whenever the ID is retrieved from FileNet, it comes with
-          // "{" and "}" surrounded and ID is in between these curly braces.
-          // FileNet connector needs ID without curly braces.  Thus removing
-          // the curly braces.
-          String id = val.toString();
-          valuesList.add(id.substring(1, id.length() - 1));
-        } else {
-          logger.log(Level.FINEST,
-              "{0} property [PropertyIdList] contains NULL value",
-              propertyName);
-        }
-      }
-    } else {
-      throw new /*TODO*/ RuntimeException("Invalid data type: "
-          + propertyName + " property is not a PropertyId type");
-    }
-  }
-
-  /**
-   * Fetches the Integer type metadata from FileNet. Responsible for
-   * distinguishing between single-valued and multi-valued metadata. If the
-   * value fetched from FileNet is of instance type List then it is
-   * multi-valued else it is single-valued.
-   */
-  @VisibleForTesting
-  void getPropertyLongValue(String propertyName, List<String> valuesList) {
-    Property prop = metas.get(propertyName);
-    if (prop == null) {
-      logger.log(Level.FINEST, "{0} property is null", propertyName);
-      return;
-    }
-    if (prop instanceof PropertyInteger32) {
-      Integer val = prop.getInteger32Value();
-      if (val != null) {
-        valuesList.add(val.toString());
-      } else {
-        logger.log(Level.FINEST,
-            "{0} property [PropertyInteger32] contains NULL value",
-            propertyName);
-      }
-    } else if (prop instanceof PropertyInteger32List) {
-      Integer32List int32List = prop.getInteger32ListValue();
-      Iterator<?> iter = int32List.iterator();
-      while (iter.hasNext()) {
-        Integer val = (Integer) iter.next();
-        if (val != null) {
-          valuesList.add(val.toString());
-        } else {
-          logger.log(Level.FINEST,
-              "{0} property [PropertyInteger32List] contains NULL value",
-              propertyName);
-        }
-      }
-    } else {
-      throw new /*TODO*/ RuntimeException("Invalid data type: "
-          + propertyName + " property is not an Integer32 or Long type");
-    }
-  }
-
-  /**
-   * Fetches the Double/Float type metadata from FileNet. Responsible for
-   * distinguishing between single-valued and multi-valued metadata. If the
-   * value fetched from FileNet is of instance type List then it is
-   * multi-valued else it is single-valued.
-   */
-  @VisibleForTesting
-  void getPropertyDoubleValue(String propertyName, List<String> valuesList) {
-    Property prop = metas.get(propertyName);
-    if (prop == null) {
-      logger.log(Level.FINEST, "{0} property is null", propertyName);
-      return;
-    }
-    if (prop instanceof PropertyFloat64) {
-      Double val = prop.getFloat64Value();
-      if (val != null) {
-        valuesList.add(val.toString());
-      } else {
-        logger.log(Level.FINEST,
-            "{0} property [PropertyFloat64] contains NULL value", propertyName);
-      }
-    } else if (prop instanceof PropertyFloat64List) {
-      Float64List float64List = prop.getFloat64ListValue();
-      Iterator<?> iter = float64List.iterator();
-      while (iter.hasNext()) {
-        Double val = (Double) iter.next();
-        if (val != null) {
-          valuesList.add(val.toString());
-        } else {
-          logger.log(Level.FINEST,
-              "{0} property [PropertyFloat64List] contains NULL value",
-              propertyName);
-        }
-      }
-    } else {
-      throw new /*TODO*/ RuntimeException("Invalid data type: "
-          + propertyName + " property is not a Double type");
-    }
-  }
-
-  /**
-   * Fetches the Date type metadata from FileNet. Responsible for
-   * distinguishing between single-valued and multi-valued metadata. If the
-   * value fetched from FileNet is of instance type List then it is
-   * multi-valued else it is single-valued.
-   */
-  @Override
-  public void getPropertyDateValue(String propertyName,
-      List<String> valuesList) {
-    Property prop = metas.get(propertyName);
-    if (prop == null) {
-      logger.log(Level.FINEST, "{0} property is null", propertyName);
-      return;
-    }
-    if (prop instanceof PropertyDateTime) {
-      Date val = prop.getDateTimeValue();
-      if (val != null) {
-        Calendar cal = Calendar.getInstance();
-        cal.setTime(val);
-        valuesList.add(/*TODO: ISO 8601*/val.toString());
-      } else {
-        logger.log(Level.FINEST,
-            "{0} property [PropertyDateTime] contains NULL value",
-            propertyName);
-      }
-    } else if (prop instanceof PropertyDateTimeList) {
-      DateTimeList dtList = prop.getDateTimeListValue();
-      Iterator<?> iter = dtList.iterator();
-      while (iter.hasNext()) {
-        Date val = (Date) iter.next();
-        if (val != null) {
-          Calendar cal = Calendar.getInstance();
-          cal.setTime(val);
-          valuesList.add(/*TODO: ISO 8601*/val.toString());
-        } else {
-          logger.log(Level.FINEST,
-              "{0} property [PropertyDateTimeList] contains NULL value",
-              propertyName);
-        }
-      }
-    } else {
-      throw new /*TODO*/ RuntimeException("Invalid data type: "
-          + propertyName + " property is not a Date type");
-    }
-  }
-
-  /**
-   * Fetches the Boolean type metadata from FileNet. Responsible for
-   * distinguishing between single-valued and multi-valued metadata. If the
-   * value fetched from FileNet is of instance type List then it is
-   * multi-valued else it is single-valued.
-   */
-  @VisibleForTesting
-  void getPropertyBooleanValue(String propertyName, List<String> valuesList) {
-    Property prop = metas.get(propertyName);
-    if (prop == null) {
-      logger.log(Level.FINEST, "{0} property is null", propertyName);
-      return;
-    }
-    if (prop instanceof PropertyBoolean) {
-      Boolean val = prop.getBooleanValue();
-      if (val != null) {
-        valuesList.add(val.toString());
-      } else {
-        logger.log(Level.FINEST,
-            "{0} property [PropertyBoolean] contains NULL value", propertyName);
-      }
-    } else if (prop instanceof PropertyBooleanList) {
-      BooleanList booleanList = prop.getBooleanListValue();
-      Iterator<?> iter = booleanList.iterator();
-      while (iter.hasNext()) {
-        Boolean val = (Boolean) iter.next();
-        if (val != null) {
-          valuesList.add(val.toString());
-        } else {
-          logger.log(Level.FINEST,
-              "{0} property [PropertyBooleanList] contains NULL value",
-              propertyName);
-        }
-      }
-    } else {
-      throw new /*TODO*/ RuntimeException("Invalid data type: "
-          + propertyName + " property is not a Boolean type");
-    }
+  public IDocumentProperties getDocumentProperties() {
+    return new FnDocumentProperties(doc);
   }
 }

--- a/src/com/google/enterprise/adaptor/filenet/FnDocumentProperties.java
+++ b/src/com/google/enterprise/adaptor/filenet/FnDocumentProperties.java
@@ -1,0 +1,370 @@
+// Copyright 2007-2010 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.enterprise.adaptor.filenet;
+
+import com.filenet.api.collection.BooleanList;
+import com.filenet.api.collection.DateTimeList;
+import com.filenet.api.collection.Float64List;
+import com.filenet.api.collection.IdList;
+import com.filenet.api.collection.Integer32List;
+import com.filenet.api.collection.StringList;
+import com.filenet.api.core.Document;
+import com.filenet.api.property.Properties;
+import com.filenet.api.property.Property;
+import com.filenet.api.property.PropertyBinary;
+import com.filenet.api.property.PropertyBinaryList;
+import com.filenet.api.property.PropertyBoolean;
+import com.filenet.api.property.PropertyBooleanList;
+import com.filenet.api.property.PropertyDateTime;
+import com.filenet.api.property.PropertyDateTimeList;
+import com.filenet.api.property.PropertyFloat64;
+import com.filenet.api.property.PropertyFloat64List;
+import com.filenet.api.property.PropertyId;
+import com.filenet.api.property.PropertyIdList;
+import com.filenet.api.property.PropertyInteger32;
+import com.filenet.api.property.PropertyInteger32List;
+import com.filenet.api.property.PropertyString;
+import com.filenet.api.property.PropertyStringList;
+import com.filenet.api.util.Id;
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+class FnDocumentProperties implements IDocumentProperties {
+  private static final Logger logger =
+      Logger.getLogger(FnDocumentProperties.class.getName());
+
+  private final Document doc;
+  private final Map<String, Property> metas;
+
+  public FnDocumentProperties(Document doc) {
+    this.doc = doc;
+    this.metas = getMetas();
+  }
+
+  private Map<String, Property> getMetas() {
+    Map<String, Property> propMap = new HashMap<>();
+    Properties props = doc.getProperties();
+    Property[] propList = props.toArray();
+    for (Property property : propList) {
+      propMap.put(property.getPropertyName(), property);
+    }
+    return propMap;
+  }
+
+  @Override
+  public Set<String> getPropertyNames() {
+    return metas.keySet();
+  }
+
+  @Override
+  public void getProperty(String name, List<String> list) {
+    Property prop = metas.get(name);
+    if (prop == null) {
+      logger.log(Level.FINEST, "Property not found: {0}", name);
+      return;
+    }
+    if (prop instanceof PropertyString
+        || prop instanceof PropertyStringList) {
+      logger.log(Level.FINEST, "Getting String property: [{0}]", name);
+      getPropertyStringValue(name, list);
+    } else if (prop instanceof PropertyBinary
+        || prop instanceof PropertyBinaryList) {
+      logger.log(Level.FINEST, "Binary property [{0}] is not supported.", name);
+    } else if (prop instanceof PropertyBoolean
+        || prop instanceof PropertyBooleanList) {
+      logger.log(Level.FINEST, "Getting Boolean property: [{0}]", name);
+      getPropertyBooleanValue(name, list);
+    } else if (prop instanceof PropertyDateTime
+        || prop instanceof PropertyDateTimeList) {
+      logger.log(Level.FINEST, "Getting Date property: [{0}]", name);
+      getPropertyDateValue(name, list);
+    } else if (prop instanceof PropertyFloat64
+        || prop instanceof PropertyFloat64List) {
+      logger.log(Level.FINEST, "Getting Double/Float property: [{0}]", name);
+      getPropertyDoubleValue(name, list);
+    } else if (prop instanceof PropertyInteger32
+        || prop instanceof PropertyInteger32List) {
+      logger.log(Level.FINEST, "Getting Integer/Long property: [{0}]", name);
+      getPropertyLongValue(name, list);
+    } else if (prop instanceof PropertyId
+        || prop instanceof PropertyIdList) {
+      logger.log(Level.FINEST, "Getting Id property: [{0}]", name);
+      getPropertyGuidValue(name, list);
+    } else {
+      logger.log(Level.FINEST, "Property type for {0} is not determined: ",
+          prop.getClass().getName());
+    }
+  }
+
+  /**
+   * Fetches the String type metadata from FileNet. Responsible for
+   * distinguishing between single-valued and multi-valued metadata. If the
+   * value fetched from FileNet is of instance type List then it is
+   * multi-valued else it is single-valued.
+   */
+  private void getPropertyStringValue(String propertyName,
+      List<String> valuesList) {
+    Property prop = metas.get(propertyName);
+    if (prop == null) {
+      logger.log(Level.FINEST, "{0} property is null", propertyName);
+      return;
+    }
+    if (prop instanceof PropertyString) {
+      String val = prop.getStringValue();
+      if (val != null) {
+        valuesList.add(val.toString());
+      } else {
+        logger.log(Level.FINEST,
+            "{0} property [PropertyString] contains NULL value", propertyName);
+      }
+    } else if (prop instanceof PropertyStringList) {
+      StringList slist = prop.getStringListValue();
+      Iterator<?> iter = slist.iterator();
+      while (iter.hasNext()) {
+        String val = (String) iter.next();
+        if (val != null) {
+          valuesList.add(val.toString());
+        } else {
+          logger.log(Level.FINEST,
+              "{0} property [PropertyStringList] contains NULL value",
+              propertyName);
+        }
+      }
+    } else {
+      throw new /*TODO*/ RuntimeException("Invalid data type: "
+          + propertyName + " property is not a String type");
+    }
+  }
+
+  /**
+   * Fetches the GUID type metadata from FileNet. Responsible for
+   * distinguishing between single-valued and multi-valued metadata. If the
+   * value fetched from FileNet is of instance type List then it is
+   * multi-valued else it is single-valued.
+   */
+  private void getPropertyGuidValue(String propertyName,
+      List<String> valuesList) {
+    Property prop = metas.get(propertyName);
+    if (prop == null) {
+      logger.log(Level.FINEST, "{0} property is null", propertyName);
+      return;
+    }
+    if (prop instanceof PropertyId) {
+      Id val = prop.getIdValue();
+      if (val != null) {
+        String id = val.toString();
+        valuesList.add(id.substring(1, id.length() - 1));
+      } else {
+        logger.log(Level.FINEST,
+            "{0} property [PropertyId] contains NULL value", propertyName);
+      }
+    } else if (prop instanceof PropertyIdList) {
+      IdList idList = prop.getIdListValue();
+      Iterator<?> iter = idList.iterator();
+      while (iter.hasNext()) {
+        Id val = (Id) iter.next();
+        if (val != null) {
+          // Whenever the ID is retrieved from FileNet, it comes with
+          // "{" and "}" surrounded and ID is in between these curly braces.
+          // FileNet connector needs ID without curly braces.  Thus removing
+          // the curly braces.
+          String id = val.toString();
+          valuesList.add(id.substring(1, id.length() - 1));
+        } else {
+          logger.log(Level.FINEST,
+              "{0} property [PropertyIdList] contains NULL value",
+              propertyName);
+        }
+      }
+    } else {
+      throw new /*TODO*/ RuntimeException("Invalid data type: "
+          + propertyName + " property is not a PropertyId type");
+    }
+  }
+
+  /**
+   * Fetches the Integer type metadata from FileNet. Responsible for
+   * distinguishing between single-valued and multi-valued metadata. If the
+   * value fetched from FileNet is of instance type List then it is
+   * multi-valued else it is single-valued.
+   */
+  private void getPropertyLongValue(String propertyName,
+      List<String> valuesList) {
+    Property prop = metas.get(propertyName);
+    if (prop == null) {
+      logger.log(Level.FINEST, "{0} property is null", propertyName);
+      return;
+    }
+    if (prop instanceof PropertyInteger32) {
+      Integer val = prop.getInteger32Value();
+      if (val != null) {
+        valuesList.add(val.toString());
+      } else {
+        logger.log(Level.FINEST,
+            "{0} property [PropertyInteger32] contains NULL value",
+            propertyName);
+      }
+    } else if (prop instanceof PropertyInteger32List) {
+      Integer32List int32List = prop.getInteger32ListValue();
+      Iterator<?> iter = int32List.iterator();
+      while (iter.hasNext()) {
+        Integer val = (Integer) iter.next();
+        if (val != null) {
+          valuesList.add(val.toString());
+        } else {
+          logger.log(Level.FINEST,
+              "{0} property [PropertyInteger32List] contains NULL value",
+              propertyName);
+        }
+      }
+    } else {
+      throw new /*TODO*/ RuntimeException("Invalid data type: "
+          + propertyName + " property is not an Integer32 or Long type");
+    }
+  }
+
+  /**
+   * Fetches the Double/Float type metadata from FileNet. Responsible for
+   * distinguishing between single-valued and multi-valued metadata. If the
+   * value fetched from FileNet is of instance type List then it is
+   * multi-valued else it is single-valued.
+   */
+  private void getPropertyDoubleValue(String propertyName,
+      List<String> valuesList) {
+    Property prop = metas.get(propertyName);
+    if (prop == null) {
+      logger.log(Level.FINEST, "{0} property is null", propertyName);
+      return;
+    }
+    if (prop instanceof PropertyFloat64) {
+      Double val = prop.getFloat64Value();
+      if (val != null) {
+        valuesList.add(val.toString());
+      } else {
+        logger.log(Level.FINEST,
+            "{0} property [PropertyFloat64] contains NULL value", propertyName);
+      }
+    } else if (prop instanceof PropertyFloat64List) {
+      Float64List float64List = prop.getFloat64ListValue();
+      Iterator<?> iter = float64List.iterator();
+      while (iter.hasNext()) {
+        Double val = (Double) iter.next();
+        if (val != null) {
+          valuesList.add(val.toString());
+        } else {
+          logger.log(Level.FINEST,
+              "{0} property [PropertyFloat64List] contains NULL value",
+              propertyName);
+        }
+      }
+    } else {
+      throw new /*TODO*/ RuntimeException("Invalid data type: "
+          + propertyName + " property is not a Double type");
+    }
+  }
+
+  /**
+   * Fetches the Date type metadata from FileNet. Responsible for
+   * distinguishing between single-valued and multi-valued metadata. If the
+   * value fetched from FileNet is of instance type List then it is
+   * multi-valued else it is single-valued.
+   */
+  private void getPropertyDateValue(String propertyName,
+      List<String> valuesList) {
+    Property prop = metas.get(propertyName);
+    if (prop == null) {
+      logger.log(Level.FINEST, "{0} property is null", propertyName);
+      return;
+    }
+    if (prop instanceof PropertyDateTime) {
+      Date val = prop.getDateTimeValue();
+      if (val != null) {
+        Calendar cal = Calendar.getInstance();
+        cal.setTime(val);
+        valuesList.add(/*TODO: ISO 8601*/val.toString());
+      } else {
+        logger.log(Level.FINEST,
+            "{0} property [PropertyDateTime] contains NULL value",
+            propertyName);
+      }
+    } else if (prop instanceof PropertyDateTimeList) {
+      DateTimeList dtList = prop.getDateTimeListValue();
+      Iterator<?> iter = dtList.iterator();
+      while (iter.hasNext()) {
+        Date val = (Date) iter.next();
+        if (val != null) {
+          Calendar cal = Calendar.getInstance();
+          cal.setTime(val);
+          valuesList.add(/*TODO: ISO 8601*/val.toString());
+        } else {
+          logger.log(Level.FINEST,
+              "{0} property [PropertyDateTimeList] contains NULL value",
+              propertyName);
+        }
+      }
+    } else {
+      throw new /*TODO*/ RuntimeException("Invalid data type: "
+          + propertyName + " property is not a Date type");
+    }
+  }
+
+  /**
+   * Fetches the Boolean type metadata from FileNet. Responsible for
+   * distinguishing between single-valued and multi-valued metadata. If the
+   * value fetched from FileNet is of instance type List then it is
+   * multi-valued else it is single-valued.
+   */
+  private void getPropertyBooleanValue(String propertyName,
+      List<String> valuesList) {
+    Property prop = metas.get(propertyName);
+    if (prop == null) {
+      logger.log(Level.FINEST, "{0} property is null", propertyName);
+      return;
+    }
+    if (prop instanceof PropertyBoolean) {
+      Boolean val = prop.getBooleanValue();
+      if (val != null) {
+        valuesList.add(val.toString());
+      } else {
+        logger.log(Level.FINEST,
+            "{0} property [PropertyBoolean] contains NULL value", propertyName);
+      }
+    } else if (prop instanceof PropertyBooleanList) {
+      BooleanList booleanList = prop.getBooleanListValue();
+      Iterator<?> iter = booleanList.iterator();
+      while (iter.hasNext()) {
+        Boolean val = (Boolean) iter.next();
+        if (val != null) {
+          valuesList.add(val.toString());
+        } else {
+          logger.log(Level.FINEST,
+              "{0} property [PropertyBooleanList] contains NULL value",
+              propertyName);
+        }
+      }
+    } else {
+      throw new /*TODO*/ RuntimeException("Invalid data type: "
+          + propertyName + " property is not a Boolean type");
+    }
+  }
+}

--- a/src/com/google/enterprise/adaptor/filenet/IDocument.java
+++ b/src/com/google/enterprise/adaptor/filenet/IDocument.java
@@ -21,8 +21,6 @@ import com.filenet.api.core.VersionSeries;
 
 import java.io.InputStream;
 import java.util.Date;
-import java.util.List;
-import java.util.Set;
 
 interface IDocument extends IBaseObject {
   Date get_DateLastModified();
@@ -31,7 +29,7 @@ interface IDocument extends IBaseObject {
 
   String get_Owner();
 
-  InputStream getContent();
+  InputStream accessContentStream(int index);
 
   Double get_ContentSize();
 
@@ -43,11 +41,5 @@ interface IDocument extends IBaseObject {
 
   Folder get_SecurityFolder();
 
-  Set<String> getPropertyNames();
-
-  void getProperty(String name, List<String> list);
-
-  void getPropertyStringValue(String name, List<String> list);
-
-  void getPropertyDateValue(String name, List<String> list);
+  IDocumentProperties getDocumentProperties();
 }

--- a/src/com/google/enterprise/adaptor/filenet/IDocumentProperties.java
+++ b/src/com/google/enterprise/adaptor/filenet/IDocumentProperties.java
@@ -1,0 +1,24 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.enterprise.adaptor.filenet;
+
+import java.util.List;
+import java.util.Set;
+
+interface IDocumentProperties {
+  Set<String> getPropertyNames();
+
+  void getProperty(String name, List<String> list);
+}

--- a/test/com/google/enterprise/adaptor/filenet/DocumentTraverserTest.java
+++ b/test/com/google/enterprise/adaptor/filenet/DocumentTraverserTest.java
@@ -17,6 +17,7 @@ package com.google.enterprise.adaptor.filenet;
 import static com.google.enterprise.adaptor.filenet.FileNetAdaptor.Checkpoint.getQueryTimeString;
 import static com.google.enterprise.adaptor.filenet.FileNetAdaptor.newDocId;
 import static com.google.enterprise.adaptor.filenet.ObjectMocks.mockDocument;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -311,10 +312,10 @@ public class DocumentTraverserTest {
     RecordingResponse response = new RecordingResponse();
     traverser.getDocContent(docList.get(0), null, response);
 
-    int contentSize =
-        ((ByteArrayOutputStream) response.getOutputStream()).size();
-    assertEquals("Content size: " + contentSize,
-        expectNotNull, contentSize > 0);
+    String expectedContent = (expectNotNull) ? "sample content" : "";
+    byte[] actualContent =
+        ((ByteArrayOutputStream) response.getOutputStream()).toByteArray();
+    assertEquals(expectedContent, new String(actualContent, UTF_8));
   }
 
   @Test

--- a/test/com/google/enterprise/adaptor/filenet/MockDocument.java
+++ b/test/com/google/enterprise/adaptor/filenet/MockDocument.java
@@ -69,7 +69,7 @@ class MockDocument implements IDocument {
   }
 
   @Override
-  public InputStream getContent() {
+  public InputStream accessContentStream(int index) {
     return new ByteArrayInputStream(
         "sample content".getBytes(StandardCharsets.UTF_8));
   }
@@ -119,45 +119,30 @@ class MockDocument implements IDocument {
   }
 
   @Override
-  public Set<String> getPropertyNames() {
-    return props.keySet();
+  public IDocumentProperties getDocumentProperties() {
+    return new MockDocumentProperties();
   }
 
-  @Override
-  public void getProperty(String name, List<String> list) {
-    if (PropertyNames.ID.equalsIgnoreCase(name)) {
-      String val = props.get(name).toString();
-      list.add(val);
-    } else if (PropertyNames.DATE_LAST_MODIFIED.equalsIgnoreCase(name)) {
-      getPropertyDateValue(name, list);
-    } else {
-      getPropertyValue(name, list);
+  private class MockDocumentProperties implements IDocumentProperties {
+    @Override
+    public Set<String> getPropertyNames() {
+      return props.keySet();
     }
-  }
 
-  private void getPropertyValue(String name, List<String> list) {
-    Object obj = props.get(name);
-    if (obj == null) {
-      return;
+    @Override
+    public void getProperty(String name, List<String> list) {
+      Object obj = props.get(name);
+      if (obj == null) {
+        return;
+      } else if (obj instanceof Date) {
+        Date val = (Date) props.get(name);
+        Calendar cal = Calendar.getInstance();
+        cal.setTime(val);
+        list.add(/*TODO: ISO 8601*/ val.toString());
+      } else {
+        String val = props.get(name).toString();
+        list.add(val);
+      }
     }
-    if (obj instanceof String) {
-      getPropertyStringValue(name, list);
-    } else if (obj instanceof Date) {
-      getPropertyDateValue(name, list);
-    }
-  }
-
-  @Override
-  public void getPropertyStringValue(String name, List<String> list) {
-    String val = (String) props.get(name);
-    list.add(val);
-  }
-
-  @Override
-  public void getPropertyDateValue(String name, List<String> list) {
-    Date val = (Date) props.get(name);
-    Calendar cal = Calendar.getInstance();
-    cal.setTime(val);
-    list.add(/*TODO: ISO 8601*/ val.toString());
   }
 }


### PR DESCRIPTION
* Move FnDocument.get_ActiveMarkings to DocumentTraverser.

* Replace FnDocument.getContent with accessContentStream (a FileNet
  API convenience method that does exactly what getContent was doing).
  Add error handling for unsupported content elements (see b/6513927).

* Move the getProperyNames and getProperty methods to a separate
  IDocumentProperties interface. Make getPropertyStringValue and
  getPropertyDateValue private; they were previously replaced by
  get_DateLastModified and get_MimeType. All of These methods and
  their helpers are unchanged except for access.