### PR TITLE
Fixes to run against FileNet live.

### DIFF
--- a/adaptor-config.properties.sample
+++ b/adaptor-config.properties.sample
@@ -2,3 +2,17 @@
 
 # Hostname or IP address of the GSA this adaptor will be feeding.
 gsa.hostname =
+
+# FileNet config.
+# Required properties.
+filenet.contentEngineUrl =
+filenet.username =
+filenet.password =
+filenet.objectStore =
+filenet.displayUrl  =
+
+# Optional properties.
+# filenet.additionalWhereClause =
+# filenet.deleteAdditionalWhereClause =
+# filenet.excludedMetadata =
+# filenet.includedMetadata =

--- a/src/com/google/enterprise/adaptor/filenet/DocumentTraverser.java
+++ b/src/com/google/enterprise/adaptor/filenet/DocumentTraverser.java
@@ -188,7 +188,8 @@ class DocumentTraverser implements FileNetAdaptor.Traverser {
       Document document = (Document)
           objectStore.fetchObject(ClassNames.DOCUMENT, guid,
               FileUtil.getDocumentPropertyFilter(
-                  options.getIncludedMetadata()));
+                  options.getIncludedMetadata(),
+                  options.getExcludedMetadata()));
 
       logger.log(Level.FINEST, "Add document [ID: {0}]", guid);
       processDocument(guid, newDocId(guid), document, response);
@@ -203,22 +204,10 @@ class DocumentTraverser implements FileNetAdaptor.Traverser {
     String vsDocId = document.get_VersionSeries().get_Id().toString();
     logger.log(Level.FINE, "VersionSeriesID for document is: {0}", vsDocId);
 
-    try {
-      ActiveMarkingList activeMarkings = document.get_ActiveMarkings();
-      if (!activeMarkings.isEmpty()) {
-        throw new UnsupportedOperationException(
-            "Document " + vsDocId + " has an active marking set.");
-      }
-    } catch (EngineRuntimeException e) {
-      // TODO(jlacey): The IBM doc suggests this is just a property
-      // filter issue, and we might get a different error if or none
-      // at all if there are no active markings.
-      if (e.getExceptionCode() == ExceptionCode.API_PROPERTY_NOT_IN_CACHE) {
-        logger.log(Level.FINER, "Assuming no active markings: {0}",
-            e.getMessage());
-      } else {
-        throw e;
-      }
+    ActiveMarkingList activeMarkings = document.get_ActiveMarkings();
+    if (!activeMarkings.isEmpty()) {
+      throw new UnsupportedOperationException(
+          "Document " + vsDocId + " has an active marking set.");
     }
     Permissions.Acl permissions =
         new Permissions(document.get_Permissions(), document.get_Owner())

--- a/src/com/google/enterprise/adaptor/filenet/FileUtil.java
+++ b/src/com/google/enterprise/adaptor/filenet/FileUtil.java
@@ -71,10 +71,13 @@ class FileUtil {
 
   /** Creates a default property filter for document. */
   public static PropertyFilter getDocumentPropertyFilter(
-      Set<String> includedMetaNames) {
+      Set<String> includedMetaNames, Set<String> excludedMetaNames) {
     Set<String> filterSet = new HashSet<String>();
-    if (includedMetaNames != null) {
+    if (includedMetaNames.isEmpty()) {
+      return null;
+    } else {
       filterSet.addAll(includedMetaNames);
+      filterSet.removeAll(excludedMetaNames);
     }
     filterSet.add(PropertyNames.ID);
     filterSet.add(PropertyNames.CLASS_DESCRIPTION);
@@ -86,6 +89,7 @@ class FileUtil {
     filterSet.add(PropertyNames.VERSION_SERIES_ID);
     filterSet.add(PropertyNames.RELEASED_VERSION);
     filterSet.add(PropertyNames.OWNER);
+    filterSet.add(PropertyNames.ACTIVE_MARKINGS);
     filterSet.add(PropertyNames.PERMISSIONS);
     filterSet.add(PropertyNames.PERMISSION_TYPE);
     filterSet.add(PropertyNames.PERMISSION_SOURCE);

--- a/src/com/google/enterprise/adaptor/filenet/FileUtil.java
+++ b/src/com/google/enterprise/adaptor/filenet/FileUtil.java
@@ -79,6 +79,7 @@ class FileUtil {
     filterSet.add(PropertyNames.ID);
     filterSet.add(PropertyNames.CLASS_DESCRIPTION);
     filterSet.add(PropertyNames.CONTENT_ELEMENTS);
+    filterSet.add(PropertyNames.CONTENT_SIZE);
     filterSet.add(PropertyNames.DATE_LAST_MODIFIED);
     filterSet.add(PropertyNames.MIME_TYPE);
     filterSet.add(PropertyNames.VERSION_SERIES);

--- a/test/com/google/enterprise/adaptor/filenet/DocumentTraverserTest.java
+++ b/test/com/google/enterprise/adaptor/filenet/DocumentTraverserTest.java
@@ -18,10 +18,11 @@ import static com.google.enterprise.adaptor.filenet.FileNetAdaptor.Checkpoint.ge
 import static com.google.enterprise.adaptor.filenet.FileNetAdaptor.newDocId;
 import static com.google.enterprise.adaptor.filenet.ObjectMocks.mockDocument;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.hamcrest.CoreMatchers.startsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.base.Strings;
@@ -30,6 +31,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.enterprise.adaptor.Acl;
 import com.google.enterprise.adaptor.DocId;
+import com.google.enterprise.adaptor.DocIdPusher.Record;
 import com.google.enterprise.adaptor.filenet.FileNetAdaptor.Checkpoint;
 import com.google.enterprise.adaptor.filenet.FileNetProxies.MockObjectStore;
 import com.google.enterprise.adaptor.testing.RecordingDocIdPusher;
@@ -99,53 +101,53 @@ public class DocumentTraverserTest {
   }
 
   @Test
-  public void testGetDocumentList_empty() throws Exception {
+  public void testGetDocIds_emptyNoResults() throws Exception {
     DocumentTraverser traverser = new DocumentTraverser(options);
     RecordingDocIdPusher pusher = new RecordingDocIdPusher();
     traverser.getDocIds(EMPTY_CHECKPOINT, pusher);
-    assertEquals(pusher.getDocIds().toString(), 0, pusher.getDocIds().size());
+    assertEquals(ImmutableList.of(), pusher.getRecords());
   }
 
   @Test
-  public void testGetDocumentList_nonEmpty() throws Exception {
+  public void testGetDocIds_emptyWithResults() throws Exception {
     MockObjectStore objectStore = getObjectStore();
     String id = "{AAAAAAAA-0000-0000-0000-000000000000}";
     Date now = new Date();
     String lastModified = dateFormatter.format(now);
     mockDocument(objectStore, id, lastModified, true,
         TestObjectFactory.getPermissions(PermissionSource.SOURCE_DIRECT));
+
     DocumentTraverser traverser = new DocumentTraverser(options);
     RecordingDocIdPusher pusher = new RecordingDocIdPusher();
     traverser.getDocIds(EMPTY_CHECKPOINT, pusher);
 
-    assertEquals(ImmutableList.of(new Id(id)), getIds(pusher.getDocIds()));
-    String checkpoint = getCheckpoint(pusher.getDocIds());
+    assertEquals(ImmutableList.of(new Id(id)), getIds(pusher.getRecords()));
+    String checkpoint = getCheckpoint(pusher.getRecords());
     assertTrue(checkpoint, checkpoint.contains(id));
     assertTrue(checkpoint,
         checkpoint.contains(Checkpoint.getQueryTimeString(now)));
   }
 
-  private ImmutableList<Id> getIds(List<DocId> docList) {
+  private ImmutableList<Id> getIds(List<Record> docList) {
     ImmutableList.Builder<Id> builder = ImmutableList.builder();
-    for (DocId docId : docList) {
-      String s = docId.getUniqueId();
-      if (s.startsWith("guid/")) {
-        builder.add(new Id(s.substring(5)));
-      }
+    for (Record record : docList.subList(0, docList.size() - 1)) {
+      String s = record.getDocId().getUniqueId();
+      assertThat(s, startsWith("guid/"));
+      assertFalse("Record is crawl-immediately",
+          record.isToBeCrawledImmediately());
+      builder.add(new Id(s.substring(5)));
     }
     return builder.build();
   }
 
-  private String getCheckpoint(List<DocId> docList) {
-    String checkpoint = null;
-    for (DocId docId : docList) {
-      String s = docId.getUniqueId();
-      if (s.startsWith("pseudo/")) {
-        assertNull(checkpoint);
-        checkpoint = s.substring(7);
-      }
-    }
-    return checkpoint;
+  private String getCheckpoint(List<Record> docList) {
+    assertTrue(docList.toString(), docList.size() > 1);
+    Record record = docList.get(docList.size() - 1);
+    String s = record.getDocId().getUniqueId();
+    assertThat(s, startsWith("pseudo/"));
+    assertTrue("Record is not crawl-immediately",
+        record.isToBeCrawledImmediately());
+    return s.substring(7);
   }
 
   @Test
@@ -177,8 +179,7 @@ public class DocumentTraverserTest {
     DocumentTraverser traverser = new DocumentTraverser(options);
     RecordingDocIdPusher pusher = new RecordingDocIdPusher();
     traverser.getDocIds(CHECKPOINT, pusher);
-    List<DocId> docList = pusher.getDocIds();
-    assertEquals(ImmutableList.of(), docList);
+    assertEquals(ImmutableList.of(), pusher.getRecords());
   }
 
   @Test
@@ -190,7 +191,7 @@ public class DocumentTraverserTest {
     DocumentTraverser traverser = new DocumentTraverser(options);
     RecordingDocIdPusher pusher = new RecordingDocIdPusher();
     traverser.getDocIds(EMPTY_CHECKPOINT, pusher);
-    List<DocId> docList = pusher.getDocIds();
+    List<Record> docList = pusher.getRecords();
     for (Id id : getIds(docList)) {
       RecordingResponse response = new RecordingResponse();
       traverser.getDocContent(id, null, response);
@@ -215,7 +216,7 @@ public class DocumentTraverserTest {
     DocumentTraverser traverser = new DocumentTraverser(options);
     RecordingDocIdPusher pusher = new RecordingDocIdPusher();
     traverser.getDocIds(CHECKPOINT, pusher);
-    List<DocId> docList = pusher.getDocIds();
+    List<Record> docList = pusher.getRecords();
     for (Id id : getIds(docList)) {
       RecordingResponse response = new RecordingResponse();
       traverser.getDocContent(id, null, response);
@@ -239,7 +240,7 @@ public class DocumentTraverserTest {
     DocumentTraverser traverser = new DocumentTraverser(options);
     RecordingDocIdPusher pusher = new RecordingDocIdPusher();
     traverser.getDocIds(CHECKPOINT, pusher);
-    List<Id> docList = getIds(pusher.getDocIds());
+    List<Id> docList = getIds(pusher.getRecords());
     assertFalse(docList.isEmpty());
 
     int counter = 0;
@@ -268,7 +269,7 @@ public class DocumentTraverserTest {
     assertTrue(String.valueOf(docEntries.length), docEntries.length > 1);
     RecordingDocIdPusher pusher = new RecordingDocIdPusher();
     traverser.getDocIds(CHECKPOINT, pusher);
-    List<DocId> docList = pusher.getDocIds();
+    List<Record> docList = pusher.getRecords();
     for (Id id : getIds(docList)) {
       RecordingResponse response = new RecordingResponse();
       traverser.getDocContent(id, null, response);
@@ -280,16 +281,6 @@ public class DocumentTraverserTest {
     assertEquals(CHECKPOINT_TIMESTAMP, getQueryTimeString(lastModified));
     assertCheckpointEquals(getCheckpoint(docList),
         CHECKPOINT_TIMESTAMP, "{AAAAAAAA-1000-0000-0000-000000000000}");
-  }
-
-  @Test
-  public void testCheckpointWithoutNextDocument() throws Exception {
-    DocumentTraverser traverser = new DocumentTraverser(options);
-    RecordingDocIdPusher pusher = new RecordingDocIdPusher();
-    traverser.getDocIds(CHECKPOINT, pusher);
-    List<DocId> docList = pusher.getDocIds();
-
-    assertEquals(ImmutableList.of(), docList);
   }
 
   @Test
@@ -307,7 +298,7 @@ public class DocumentTraverserTest {
     DocumentTraverser traverser = new DocumentTraverser(options);
     RecordingDocIdPusher pusher = new RecordingDocIdPusher();
     traverser.getDocIds(CHECKPOINT, pusher);
-    List<Id> docList = getIds(pusher.getDocIds());
+    List<Id> docList = getIds(pusher.getRecords());
 
     RecordingResponse response = new RecordingResponse();
     traverser.getDocContent(docList.get(0), null, response);

--- a/test/com/google/enterprise/adaptor/filenet/FileUtilTest.java
+++ b/test/com/google/enterprise/adaptor/filenet/FileUtilTest.java
@@ -14,12 +14,75 @@
 
 package com.google.enterprise.adaptor.filenet;
 
+import static java.util.Arrays.asList;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.collect.ImmutableSet;
+
+import com.filenet.api.constants.PropertyNames;
+import com.filenet.api.property.PropertyFilter;
 
 import org.junit.Test;
 
+import java.util.List;
+
 /** Tests the FileUtil utility class. */
 public class FileUtilTest {
+  /** Tests that including nothing explicitly fetches everything. */
+  @Test
+  public void testGetDocumentPropertyFilter_emptyEmpty() {
+    assertNull(
+        FileUtil.getDocumentPropertyFilter(
+            ImmutableSet.<String>of(),
+            ImmutableSet.<String>of()));
+  }
+
+  /** Tests that excluding properties still fetches everything. */
+  @Test
+  public void testGetDocumentPropertyFilter_emptyNonempty() {
+    assertNull(
+        FileUtil.getDocumentPropertyFilter(
+            ImmutableSet.<String>of(),
+            ImmutableSet.of(PropertyNames.DATE_CREATED, PropertyNames.ID)));
+  }
+
+  /** Tests that included properties are added to the filter. */
+  @Test
+  public void testGetDocumentPropertyFilter_nonemptyEmpty() {
+    PropertyFilter filter =
+        FileUtil.getDocumentPropertyFilter(
+            // This should be something that we don't fetch by default.
+            ImmutableSet.of(PropertyNames.DATE_CREATED),
+            ImmutableSet.<String>of());
+    assertNotNull(filter);
+    assertEquals(filter.toString(), 1, filter.getIncludeProperties().length);
+    List<String> names =
+        asList(filter.getIncludeProperties()[0].getValue().split(" "));
+    assertThat(names, hasItem(PropertyNames.DATE_CREATED));
+    assertThat(names, hasItem(PropertyNames.ID));
+  }
+
+  /** Tests that we can exclude included properties, but not builtin ones. */
+  @Test
+  public void testGetDocumentPropertyFilter_nonemptyNonempty() {
+    PropertyFilter filter =
+        FileUtil.getDocumentPropertyFilter(
+            // This should be something that we don't fetch by default.
+            ImmutableSet.of(PropertyNames.DATE_CREATED),
+            ImmutableSet.of(PropertyNames.DATE_CREATED, PropertyNames.ID));
+    assertNotNull(filter);
+    assertEquals(filter.toString(), 1, filter.getIncludeProperties().length);
+    List<String> names =
+        asList(filter.getIncludeProperties()[0].getValue().split(" "));
+    assertThat(names, not(hasItem(PropertyNames.DATE_CREATED)));
+    assertThat(names, hasItem(PropertyNames.ID));
+  }
+
   @Test
   public void testConvertDn_email() {
     assertEquals("jsmith@example.com",


### PR DESCRIPTION
* Add adaptor-config.properties.sample.
* Add ContentSize to the PropertyFilter for fetchObject.
* Add setCrawlImmediately(true) to all checkpoints, with tests.

Other changes:

* Remove testCheckpointWithoutNextDocument, a duplicate of
  testGetDocIds_noResults.