### PR TITLE
Make continuation URLs crawl-once and delete when crawled.

### DIFF
--- a/src/com/google/enterprise/adaptor/filenet/ConfigOptions.java
+++ b/src/com/google/enterprise/adaptor/filenet/ConfigOptions.java
@@ -146,9 +146,9 @@ class ConfigOptions {
 
     try {
       maxFeedUrls = Integer.parseInt(config.getValue("feed.maxUrls"));
-      if (maxFeedUrls < 2) {
+      if (maxFeedUrls < 3) {
         throw new InvalidConfigurationException(
-            "feed.maxUrls must be greater than 1: " + maxFeedUrls);
+            "feed.maxUrls must be greater than 2: " + maxFeedUrls);
       }
     } catch (NumberFormatException e) {
       throw new InvalidConfigurationException(

--- a/src/com/google/enterprise/adaptor/filenet/FileNetAdaptor.java
+++ b/src/com/google/enterprise/adaptor/filenet/FileNetAdaptor.java
@@ -109,7 +109,7 @@ public class FileNetAdaptor extends AbstractAdaptor {
       InterruptedException {
     pusher.pushRecords(Arrays.asList(
         new Record.Builder(newDocId(new Checkpoint("document", null, null)))
-            .setCrawlImmediately(true).build()));
+            .setCrawlImmediately(true).setCrawlOnce(true).build()));
   }
 
   @Override
@@ -128,7 +128,9 @@ public class FileNetAdaptor extends AbstractAdaptor {
         switch (checkpoint.type) {
           case "document":
             documentTraverser.getDocIds(checkpoint, context.getDocIdPusher());
+            resp.setCrawlOnce(true); // TODO(jlacey): Required by the library.
             resp.setNoIndex(true);
+            resp.setSecure(true); // Just to be paranoid.
             resp.setContentType("text/plain");
             resp.getOutputStream().write(" ".getBytes(UTF_8));
             break;

--- a/test/com/google/enterprise/adaptor/filenet/FileNetAdaptorTest.java
+++ b/test/com/google/enterprise/adaptor/filenet/FileNetAdaptorTest.java
@@ -460,7 +460,7 @@ public class FileNetAdaptorTest {
   public void testInit_maxFeedUrls_tooSmall() throws Exception {
     config.overrideKey("feed.maxUrls", "1");
     thrown.expect(InvalidConfigurationException.class);
-    thrown.expectMessage("feed.maxUrls must be greater than 1");
+    thrown.expectMessage("feed.maxUrls must be greater than 2");
     adaptor.init(context);
   }
 
@@ -473,7 +473,7 @@ public class FileNetAdaptorTest {
 
     assertEquals(ImmutableList.of(
         new Record.Builder(newDocId(new Checkpoint("type=document")))
-            .setCrawlImmediately(true).build()),
+            .setCrawlImmediately(true).setCrawlOnce(true).build()),
         pusher.getRecords());
   }
 
@@ -527,6 +527,8 @@ public class FileNetAdaptorTest {
     adaptor.getDocContent(
         new MockRequest(newDocId(new Checkpoint("type=document"))),
         response);
+    assertTrue(response.isCrawlOnce());
+    assertTrue(response.isNoIndex());
 
     List<Record> actual = getContextPusher().getRecords();
     // Assert that the pushed DocIds match.
@@ -563,6 +565,8 @@ public class FileNetAdaptorTest {
     RecordingResponse response = new RecordingResponse();
     adaptor.getDocContent(
         new MockRequest(newDocId(startCheckpoint)), response);
+    assertTrue(response.isCrawlOnce());
+    assertTrue(response.isNoIndex());
 
     List<Record> actual = getContextPusher().getRecords();
     // Assert that the pushed DocIds match.
@@ -610,6 +614,8 @@ public class FileNetAdaptorTest {
     adaptor.getDocContent(
         new MockRequest(newDocId("{AAAAAAAA-0000-0000-0000-000000000004}")),
         response);
+    assertFalse(response.isCrawlOnce());
+    assertFalse(response.isNoIndex());
     assertEquals("text/plain", response.getContentType());
     assertEquals("Hello from document {AAAAAAAA-0000-0000-0000-000000000004}",
         baos.toString("UTF-8"));


### PR DESCRIPTION
Avoid recrawling continuation URLs and delete the current one
when sending the new one for the next batch.