### PR TITLE
Make continuation URLs crawl-once and delete when crawled.

### DIFF
--- a/src/com/google/enterprise/adaptor/filenet/ConfigOptions.java
+++ b/src/com/google/enterprise/adaptor/filenet/ConfigOptions.java
@@ -146,9 +146,9 @@ class ConfigOptions {
 
     try {
       maxFeedUrls = Integer.parseInt(config.getValue("feed.maxUrls"));
-      if (maxFeedUrls < 2) {
+      if (maxFeedUrls < 3) {
         throw new InvalidConfigurationException(
-            "feed.maxUrls must be greater than 1: " + maxFeedUrls);
+            "feed.maxUrls must be greater than 2: " + maxFeedUrls);
       }
     } catch (NumberFormatException e) {
       throw new InvalidConfigurationException(

--- a/src/com/google/enterprise/adaptor/filenet/DocumentTraverser.java
+++ b/src/com/google/enterprise/adaptor/filenet/DocumentTraverser.java
@@ -80,9 +80,12 @@ class DocumentTraverser implements FileNetAdaptor.Traverser {
       Logger.getLogger(DocumentTraverser.class.getName());
 
   private final ConfigOptions options;
+  private final int maxRecords;
 
   public DocumentTraverser(ConfigOptions options) {
     this.options = options;
+    // Leave room for the continuation URLs.
+    this.maxRecords = options.getMaxFeedUrls() - 2;
   }
 
   /** Percent escapes the curly braces in an Id string. */
@@ -105,7 +108,7 @@ class DocumentTraverser implements FileNetAdaptor.Traverser {
       logger.log(Level.FINE, "Query for added or updated documents: {0}",
           query);
       IndependentObjectSet objectSet = search.fetchObjects(query,
-          options.getMaxFeedUrls() - 1, SearchWrapper.dereferenceObjects,
+          maxRecords, SearchWrapper.dereferenceObjects,
           SearchWrapper.ALL_ROWS);
       logger.fine(objectSet.isEmpty()
           ? "Found no documents to add or update"
@@ -121,13 +124,17 @@ class DocumentTraverser implements FileNetAdaptor.Traverser {
         guid = object.get_Id(); // TODO: Use the VersionSeries ID.
         records.add(new DocIdPusher.Record.Builder(newDocId(guid)).build());
       }
+      // TODO(jlacey): if (records.size() == maxRecords)
       if (timestamp != null) {
         records.add(
             new DocIdPusher.Record.Builder(
                 newDocId(new Checkpoint(checkpoint.type, timestamp, guid)))
             .setCrawlImmediately(true).build());
-        pusher.pushRecords(records);
       }
+      records.add(
+          new DocIdPusher.Record.Builder(newDocId(checkpoint))
+          .setDeleteFromIndex(true).build());
+      pusher.pushRecords(records);
     } catch (EngineRuntimeException e) {
       throw new IOException(e);
     }
@@ -141,7 +148,7 @@ class DocumentTraverser implements FileNetAdaptor.Traverser {
    */
   private String buildQueryString(Checkpoint checkpoint) {
     StringBuilder query = new StringBuilder("SELECT TOP ");
-    query.append(options.getMaxFeedUrls() - 1);
+    query.append(maxRecords);
     query.append(" ");
     query.append(PropertyNames.ID);
     query.append(",");
@@ -157,7 +164,7 @@ class DocumentTraverser implements FileNetAdaptor.Traverser {
       if ((additionalWhereClause.toUpperCase()).startsWith("SELECT ID,DATELASTMODIFIED FROM ")) {
         query = new StringBuilder(additionalWhereClause);
         query.replace(0, 6,
-            "SELECT TOP " + (options.getMaxFeedUrls() - 1) + " ");
+            "SELECT TOP " + maxRecords + " ");
         logger.log(Level.FINE, "Using Custom Query[{0}]",
             additionalWhereClause);
       } else {

--- a/src/com/google/enterprise/adaptor/filenet/FileNetAdaptor.java
+++ b/src/com/google/enterprise/adaptor/filenet/FileNetAdaptor.java
@@ -128,7 +128,9 @@ public class FileNetAdaptor extends AbstractAdaptor {
         switch (checkpoint.type) {
           case "document":
             documentTraverser.getDocIds(checkpoint, context.getDocIdPusher());
+            resp.setCrawlOnce(true);
             resp.setNoIndex(true);
+            resp.setSecure(true); // Just to be paranoid.
             resp.setContentType("text/plain");
             resp.getOutputStream().write(" ".getBytes(UTF_8));
             break;

--- a/test/com/google/enterprise/adaptor/filenet/FileNetAdaptorTest.java
+++ b/test/com/google/enterprise/adaptor/filenet/FileNetAdaptorTest.java
@@ -460,7 +460,7 @@ public class FileNetAdaptorTest {
   public void testInit_maxFeedUrls_tooSmall() throws Exception {
     config.overrideKey("feed.maxUrls", "1");
     thrown.expect(InvalidConfigurationException.class);
-    thrown.expectMessage("feed.maxUrls must be greater than 1");
+    thrown.expectMessage("feed.maxUrls must be greater than 2");
     adaptor.init(context);
   }
 
@@ -527,6 +527,8 @@ public class FileNetAdaptorTest {
     adaptor.getDocContent(
         new MockRequest(newDocId(new Checkpoint("type=document"))),
         response);
+    assertTrue(response.isCrawlOnce());
+    assertTrue(response.isNoIndex());
 
     List<Record> actual = getContextPusher().getRecords();
     // Assert that the pushed DocIds match.
@@ -563,6 +565,8 @@ public class FileNetAdaptorTest {
     RecordingResponse response = new RecordingResponse();
     adaptor.getDocContent(
         new MockRequest(newDocId(startCheckpoint)), response);
+    assertTrue(response.isCrawlOnce());
+    assertTrue(response.isNoIndex());
 
     List<Record> actual = getContextPusher().getRecords();
     // Assert that the pushed DocIds match.
@@ -610,6 +614,8 @@ public class FileNetAdaptorTest {
     adaptor.getDocContent(
         new MockRequest(newDocId("{AAAAAAAA-0000-0000-0000-000000000004}")),
         response);
+    assertFalse(response.isCrawlOnce());
+    assertFalse(response.isNoIndex());
     assertEquals("text/plain", response.getContentType());
     assertEquals("Hello from document {AAAAAAAA-0000-0000-0000-000000000004}",
         baos.toString("UTF-8"));


### PR DESCRIPTION
Avoid recrawling continuation URLs and delete the current one when
sending the new one for the next batch. The URLs are not crawl-once
when fed so that they will be recrawled in case of errors.