### PR TITLE
Use a configurable SimpleDateFormat for Date metadata.

### DIFF
--- a/src/com/google/enterprise/adaptor/filenet/ConfigOptions.java
+++ b/src/com/google/enterprise/adaptor/filenet/ConfigOptions.java
@@ -148,21 +148,20 @@ class ConfigOptions {
 
     final String metadataDateFormat =
         config.getValue("filenet.metadataDateFormat");
-    this.metadataDateFormat =
-        new ThreadLocal<SimpleDateFormat>() {
-          @Override protected SimpleDateFormat initialValue() {
-            return new SimpleDateFormat(metadataDateFormat);
-          }
-        };
     try {
-      this.metadataDateFormat.get();
-      this.metadataDateFormat.remove();
+      new SimpleDateFormat(metadataDateFormat);
     } catch (IllegalArgumentException e) {
       throw new InvalidConfigurationException(
           "Invalid filenet.metadataDateFormat value: " + e.getMessage());
     }
     logger.log(Level.CONFIG, "filenet.metadataDateFormat: {0}",
         metadataDateFormat);
+    this.metadataDateFormat =
+        new ThreadLocal<SimpleDateFormat>() {
+          @Override protected SimpleDateFormat initialValue() {
+            return new SimpleDateFormat(metadataDateFormat);
+          }
+        };
 
     try {
       maxFeedUrls = Integer.parseInt(config.getValue("feed.maxUrls"));

--- a/src/com/google/enterprise/adaptor/filenet/DocumentTraverser.java
+++ b/src/com/google/enterprise/adaptor/filenet/DocumentTraverser.java
@@ -61,7 +61,6 @@ import java.io.OutputStream;
 import java.net.URI;
 import java.text.MessageFormat;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
@@ -453,9 +452,7 @@ class DocumentTraverser implements FileNetAdaptor.Traverser {
 
   private void getListValue(List<?> values, List<String> valuesList) {
     for (Object val : values) {
-      if (val != null) {
-        valuesList.add(val.toString());
-      }
+      getValue(val, valuesList);
     }
   }
 
@@ -468,28 +465,19 @@ class DocumentTraverser implements FileNetAdaptor.Traverser {
 
   private void getGuidListValue(List<?> values, List<String> valuesList) {
     for (Object val : values) {
-      if (val != null) {
-        String id = val.toString();
-        valuesList.add(id.substring(1, id.length() - 1));
-      }
+      getGuidValue((Id) val, valuesList);
     }
   }
 
   private void getDateValue(Date val, List<String> valuesList) {
     if (val != null) {
-      Calendar cal = Calendar.getInstance();
-      cal.setTime(val);
-      valuesList.add(/*TODO: ISO 8601*/val.toString());
+      valuesList.add(options.getMetadataDateFormat().format(val));
     }
   }
 
   private void getDateListValue(List<?> values, List<String> valuesList) {
     for (Object val : values) {
-      if (val != null) {
-        Calendar cal = Calendar.getInstance();
-        cal.setTime((Date) val);
-        valuesList.add(/*TODO: ISO 8601*/val.toString());
-      }
+      getDateValue((Date) val, valuesList);
     }
   }
 

--- a/src/com/google/enterprise/adaptor/filenet/FileNetAdaptor.java
+++ b/src/com/google/enterprise/adaptor/filenet/FileNetAdaptor.java
@@ -72,6 +72,7 @@ public class FileNetAdaptor extends AbstractAdaptor {
     config.addKey("filenet.deleteAdditionalWhereClause", "");
     config.addKey("filenet.excludedMetadata", "");
     config.addKey("filenet.includedMetadata", "");
+    config.addKey("filenet.metadataDateFormat", "yyyy-MM-dd");
     config.addKey("adaptor.namespace", DEFAULT_NAMESPACE);
   }
 

--- a/test/com/google/enterprise/adaptor/filenet/DocumentTraverserTest.java
+++ b/test/com/google/enterprise/adaptor/filenet/DocumentTraverserTest.java
@@ -32,10 +32,10 @@ import static org.junit.Assert.assertTrue;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.google.enterprise.adaptor.Acl;
 import com.google.enterprise.adaptor.DocId;
 import com.google.enterprise.adaptor.DocIdPusher.Record;
+import com.google.enterprise.adaptor.Metadata;
 import com.google.enterprise.adaptor.Request;
 import com.google.enterprise.adaptor.filenet.EngineCollectionMocks.ActiveMarkingListMock;
 import com.google.enterprise.adaptor.filenet.FileNetAdaptor.Checkpoint;
@@ -74,6 +74,8 @@ public class DocumentTraverserTest {
 
   private static final String DOCUMENT_TIMESTAMP =
       "2014-01-01T20:00:00.000";
+  private static final String DOCUMENT_DATE =
+      DOCUMENT_TIMESTAMP.substring(0, DOCUMENT_TIMESTAMP.indexOf('T'));
 
   private static final String CHECKPOINT_TIMESTAMP;
 
@@ -360,8 +362,11 @@ public class DocumentTraverserTest {
     traverser.getDocContent(new Id(id), request, response);
 
     assertEquals(
-        ImmutableSet.of(PropertyNames.ID, PropertyNames.DATE_LAST_MODIFIED),
-        response.getMetadata().getKeys());
+        new Metadata(
+            ImmutableMap.of(PropertyNames.ID, id.substring(1, id.length() - 1),
+                PropertyNames.DATE_LAST_MODIFIED, DOCUMENT_DATE)
+            .entrySet()),
+        response.getMetadata());
 
     Acl acl = response.getAcl();
     assertFalse(acl.getPermitUsers().toString(),
@@ -404,8 +409,11 @@ public class DocumentTraverserTest {
     traverser.getDocContent(new Id(id), request, response);
 
     assertEquals(
-        ImmutableSet.of(PropertyNames.ID, PropertyNames.DATE_LAST_MODIFIED),
-        response.getMetadata().getKeys());
+        new Metadata(
+            ImmutableMap.of(PropertyNames.ID, id.substring(1, id.length() - 1),
+                PropertyNames.DATE_LAST_MODIFIED, DOCUMENT_DATE)
+            .entrySet()),
+        response.getMetadata());
 
     byte[] actualContent = baos.toByteArray();
     assertEquals("sample content", new String(actualContent, UTF_8));
@@ -433,8 +441,11 @@ public class DocumentTraverserTest {
     traverser.getDocContent(new Id(id), request, response);
 
     assertEquals(
-        ImmutableSet.of(PropertyNames.ID, PropertyNames.DATE_LAST_MODIFIED),
-        response.getMetadata().getKeys());
+        new Metadata(
+            ImmutableMap.of(PropertyNames.ID, id.substring(1, id.length() - 1),
+                PropertyNames.DATE_LAST_MODIFIED, DOCUMENT_DATE)
+            .entrySet()),
+        response.getMetadata());
 
     assertNotNull(response.getAcl());
     assertFalse(response.getNamedResources().isEmpty());
@@ -469,9 +480,13 @@ public class DocumentTraverserTest {
     traverser.getDocContent(new Id(id), request, response);
 
     assertEquals(
-        ImmutableSet.of(PropertyNames.ID, PropertyNames.DATE_LAST_MODIFIED,
-            PropertyNames.CONTENT_SIZE, PropertyNames.MIME_TYPE),
-        response.getMetadata().getKeys());
+        new Metadata(
+            ImmutableMap.of(PropertyNames.ID, id.substring(1, id.length() - 1),
+                PropertyNames.DATE_LAST_MODIFIED, DOCUMENT_DATE,
+                PropertyNames.CONTENT_SIZE, "1000.0",
+                PropertyNames.MIME_TYPE, "text/plain")
+            .entrySet()),
+        response.getMetadata());
 
     assertEquals("text/plain", response.getContentType());
     byte[] actualContent =

--- a/test/com/google/enterprise/adaptor/filenet/FileNetAdaptorTest.java
+++ b/test/com/google/enterprise/adaptor/filenet/FileNetAdaptorTest.java
@@ -442,6 +442,29 @@ public class FileNetAdaptorTest {
   }
 
   @Test
+  public void testInit_metadataDateFormat() throws Exception {
+    config.overrideKey("filenet.metadataDateFormat", "yyyy-DD");
+    adaptor.init(context);
+    assertEquals("yyyy-DD",
+        getConfigOptions().getMetadataDateFormat().toPattern());
+  }
+
+  @Test
+  public void testInit_metadataDateFormat_default() throws Exception {
+    adaptor.init(context);
+    assertEquals("yyyy-MM-dd",
+        getConfigOptions().getMetadataDateFormat().toPattern());
+  }
+
+  @Test
+  public void testInit_metadataDateFormat_invalid() throws Exception {
+    config.overrideKey("filenet.metadataDateFormat", "yyyy-jj");
+    thrown.expect(InvalidConfigurationException.class);
+    thrown.expectMessage("Invalid filenet.metadataDateFormat value:");
+    adaptor.init(context);
+  }
+
+  @Test
   public void testInit_maxFeedUrls() throws Exception {
     config.overrideKey("feed.maxUrls", "10");
     adaptor.init(context);


### PR DESCRIPTION
Design copied from the OpenText connector. This allows customers to
choose between date search operators and dynamic navigation, or
precise timestamps.