### PR TITLE
Internal TODOs in ConfigOptions and Checkpoint.

### DIFF
--- a/src/com/google/enterprise/adaptor/filenet/ConfigOptions.java
+++ b/src/com/google/enterprise/adaptor/filenet/ConfigOptions.java
@@ -14,6 +14,8 @@
 
 package com.google.enterprise.adaptor.filenet;
 
+import static com.google.enterprise.adaptor.filenet.DocumentTraverser.percentEscape;
+
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableSet;
 import com.google.enterprise.adaptor.AdaptorContext;
@@ -22,6 +24,7 @@ import com.google.enterprise.adaptor.InvalidConfigurationException;
 import com.google.enterprise.adaptor.SensitiveValueDecoder;
 
 import com.filenet.api.core.ObjectStore;
+import com.filenet.api.util.Id;
 
 import java.net.URISyntaxException;
 import java.text.SimpleDateFormat;
@@ -93,6 +96,7 @@ class ConfigOptions {
     }
     logger.log(Level.CONFIG, "filenet.objectFactory: {0}", objectFactoryName);
 
+    // TODO(jlacey): Replace this with a MessageFormat pattern.
     String workplaceUrl = config.getValue("filenet.displayUrl");
     if (workplaceUrl.endsWith("/getContent/")) {
       workplaceUrl = workplaceUrl.substring(0, workplaceUrl.length() - 1);
@@ -108,7 +112,8 @@ class ConfigOptions {
     displayUrl = workplaceUrl;
     logger.log(Level.CONFIG, "displayUrl: {0}", displayUrl);
     try {
-      new ValidatedUri(displayUrl + "0").logUnreachableHost();
+      new ValidatedUri(displayUrl + percentEscape(Id.ZERO_ID.toString()))
+          .logUnreachableHost();
     } catch (URISyntaxException e) {
       throw new InvalidConfigurationException(
           "Invalid displayUrl: " + e.getMessage());

--- a/src/com/google/enterprise/adaptor/filenet/ConfigOptions.java
+++ b/src/com/google/enterprise/adaptor/filenet/ConfigOptions.java
@@ -56,13 +56,8 @@ class ConfigOptions {
 
   public ConfigOptions(AdaptorContext context)
       throws InvalidConfigurationException {
-    this(context.getConfig(), context.getSensitiveValueDecoder());
-  }
-
-  // TODO(jlacey): Hack for testing. Replace with mock AdaptorContext.
-  ConfigOptions(Config config,
-      SensitiveValueDecoder sensitiveValueDecoder) {
-    this.sensitiveValueDecoder = sensitiveValueDecoder;
+    Config config = context.getConfig();
+    sensitiveValueDecoder = context.getSensitiveValueDecoder();
 
     contentEngineUrl = config.getValue("filenet.contentEngineUrl");
     logger.log(Level.CONFIG, "filenet.contentEngineUrl: {0}", contentEngineUrl);

--- a/src/com/google/enterprise/adaptor/filenet/DocumentTraverser.java
+++ b/src/com/google/enterprise/adaptor/filenet/DocumentTraverser.java
@@ -115,7 +115,7 @@ class DocumentTraverser implements FileNetAdaptor.Traverser {
 
       ArrayList<DocIdPusher.Record> records = new ArrayList<>();
       Date timestamp = null;
-      Id guid = null; // TODO: Id.ZERO_ID?
+      Id guid = null;
       Iterator<?> objects = objectSet.iterator();
       while (objects.hasNext()) {
         Document object = (Document) objects.next();
@@ -193,10 +193,6 @@ class DocumentTraverser implements FileNetAdaptor.Traverser {
   String getCheckpointClause(Checkpoint checkPoint) {
     String c = checkPoint.timestamp;
     String uuid = checkPoint.guid;
-    // TODO(jlacey): This can't happen. Make sure of that and remove this.
-    if (uuid.equals("")) {
-      uuid = Id.ZERO_ID.toString();
-    }
     logger.log(Level.FINE, "MakeCheckpointQueryString date: {0}", c);
     logger.log(Level.FINE, "MakeCheckpointQueryString ID: {0}", uuid);
     String whereClause = " AND (("
@@ -241,8 +237,6 @@ class DocumentTraverser implements FileNetAdaptor.Traverser {
     }
 
     response.setContentType(document.get_MimeType());
-    // TODO(jlacey): Use ValidatedUri. Use a percent encoder, or URI's
-    // multi-argument constructors?
     response.setDisplayUrl(
         URI.create(options.getDisplayUrl() + percentEscape(vsDocId)));
     response.setLastModified(document.get_DateLastModified());

--- a/test/com/google/enterprise/adaptor/filenet/FileNetProxies.java
+++ b/test/com/google/enterprise/adaptor/filenet/FileNetProxies.java
@@ -38,6 +38,7 @@ import com.filenet.api.core.Document;
 import com.filenet.api.core.IndependentObject;
 import com.filenet.api.core.ObjectStore;
 import com.filenet.api.exception.EngineRuntimeException;
+import com.filenet.api.exception.ExceptionCode;
 import com.filenet.api.property.PropertyFilter;
 import com.filenet.api.util.Id;
 
@@ -179,8 +180,8 @@ class FileNetProxies implements ObjectFactory {
       if (ClassNames.DOCUMENT.equals(type)) {
         Document obj = objects.get(id);
         if (obj == null) {
-          throw new /*TODO*/ RuntimeException("Unable to fetch document "
-              + id);
+          throw new EngineRuntimeException(
+              ExceptionCode.DB_OBJECT_DOES_NOT_EXIST);
         } else {
           return obj;
         }
@@ -269,8 +270,8 @@ class FileNetProxies implements ObjectFactory {
         }
         return new IndependentObjectSetMock(newObjects);
       } catch (SQLException e) {
-        // TODO(jlacey): Test this with null arguments.
-        throw new EngineRuntimeException(e, null, null);
+        throw new EngineRuntimeException(ExceptionCode.DB_ERROR,
+            new Object[] { e.getErrorCode(), e.getMessage() });
       }
     }
   }

--- a/test/com/google/enterprise/adaptor/filenet/TestObjectFactory.java
+++ b/test/com/google/enterprise/adaptor/filenet/TestObjectFactory.java
@@ -15,8 +15,8 @@
 package com.google.enterprise.adaptor.filenet;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.enterprise.adaptor.AdaptorContext;
 import com.google.enterprise.adaptor.Config;
-import com.google.enterprise.adaptor.SensitiveValueDecoder;
 import com.google.enterprise.adaptor.filenet.EngineCollectionMocks.AccessPermissionListMock;
 
 import com.filenet.api.collection.AccessPermissionList;
@@ -31,21 +31,14 @@ import java.util.List;
 import java.util.Map;
 
 class TestObjectFactory {
-  private static final SensitiveValueDecoder SENSITIVE_VALUE_DECODER =
-      new SensitiveValueDecoder() {
-        @Override
-        public String decodeValue(String notEncodedDuringTesting) {
-          return notEncodedDuringTesting;
-        }
-      };
-
   public static ConfigOptions newConfigOptions() {
     return newConfigOptions(ImmutableMap.<String, String>of());
   }
 
   public static ConfigOptions newConfigOptions(Map<String, String> extra) {
     FileNetAdaptor adaptor = new FileNetAdaptor();
-    Config config = new Config();
+    AdaptorContext context = ProxyAdaptorContext.getInstance();
+    Config config = context.getConfig();
     adaptor.initConfig(config);
     config.overrideKey("filenet.username", "whatever");
     config.overrideKey("filenet.password", "opensesame");
@@ -58,7 +51,7 @@ class TestObjectFactory {
     for (Map.Entry<String, String> entry : extra.entrySet()) {
       config.overrideKey(entry.getKey(), entry.getValue());
     }
-    return new ConfigOptions(config, SENSITIVE_VALUE_DECODER);
+    return new ConfigOptions(context);
   }
 
   public static AccessPermissionList getPermissions(


### PR DESCRIPTION
* Remove extra constructor for ConfigOptions and use
  ProxyAdaptorContext in the tests.
* Prevent empty and invalid timestamp and GUID strings in Checkpoint.
* Fix thread-safety of MessageFormat in Checkpoint.