### PR TITLE
Fix Marking ACL creation

### DIFF
--- a/src/com/google/enterprise/adaptor/filenet/DocumentTraverser.java
+++ b/src/com/google/enterprise/adaptor/filenet/DocumentTraverser.java
@@ -312,7 +312,8 @@ class DocumentTraverser implements FileNetAdaptor.Traverser {
       ActiveMarking activeMarking = (ActiveMarking) iterator.next();
       Marking marking = activeMarking.get_Marking();
       Permissions.Acl markingPerms =
-          new Permissions(marking.get_Permissions()).getAcl();
+          new Permissions(marking.get_Permissions())
+          .getMarkingAcl(marking.get_ConstraintMask());
       Acl markingAcl = createAcl(docId, fragment,
           Acl.InheritanceType.AND_BOTH_PERMIT,
           markingPerms.getAllowUsers(), markingPerms.getDenyUsers(),

--- a/src/com/google/enterprise/adaptor/filenet/Permissions.java
+++ b/src/com/google/enterprise/adaptor/filenet/Permissions.java
@@ -64,7 +64,7 @@ class Permissions {
   public static final String AUTHENTICATED_USERS = "#AUTHENTICATED-USERS";
   private static final String CREATOR_OWNER = "#CREATOR-OWNER";
 
-  private static final int VIEW_ACCESS_RIGHTS =
+  public static final int VIEW_ACCESS_RIGHTS =
       AccessRight.READ_AS_INT | AccessRight.VIEW_CONTENT_AS_INT;
   private static final int USE_MARKING = AccessRight.USE_MARKING_AS_INT;
 
@@ -339,10 +339,10 @@ class Permissions {
         allowGroups.put(PermissionSource.MARKING, AUTHENTICATED_USERS);
       } else {
         // If we added a denyGroups of AUTHENTICATED_USERS, the ACL would
-        // end up denying everybody, since the GSA ACL model would not reflect
+        // end up denying everybody, since the ACL chain would not reflect
         // how use rights trump the constraint mask. However, AND_BOTH_PERMIT
         // allows this to work itself out, since anyone not explicitly
-        // granted ALLOW rights, would be denied anyway.
+        // granted ALLOW rights, will be denied anyway.
       }
     }
 

--- a/src/com/google/enterprise/adaptor/filenet/Permissions.java
+++ b/src/com/google/enterprise/adaptor/filenet/Permissions.java
@@ -269,21 +269,22 @@ class Permissions {
     return new Acl();
   }
 
+  public Permissions.Acl getMarkingAcl(int constraintMask) {
+    return new Acl(constraintMask);
+  }
+
   public class Acl {
-    private final SetMultimap<PermissionSource, String> allowUsers;
-    private final SetMultimap<PermissionSource, String> allowGroups;
-    private final SetMultimap<PermissionSource, String> denyUsers;
-    private final SetMultimap<PermissionSource, String> denyGroups;
+    private final SetMultimap<PermissionSource, String> allowUsers =
+        HashMultimap.create();
+    private final SetMultimap<PermissionSource, String> allowGroups =
+        HashMultimap.create();
+    private final SetMultimap<PermissionSource, String> denyUsers =
+        HashMultimap.create();
+    private final SetMultimap<PermissionSource, String> denyGroups =
+        HashMultimap.create();
 
+    /** Builds and ACL from direct, folder, or policy Permissions. */
     private Acl() {
-      this.allowUsers = HashMultimap.create();
-      this.allowGroups = HashMultimap.create();
-      this.denyUsers = HashMultimap.create();
-      this.denyGroups = HashMultimap.create();
-      processPermissions();
-    }
-
-    private void processPermissions() {
       Iterator<?> iter = perms.iterator();
       while (iter.hasNext()) {
         AccessPermission perm = (AccessPermission) iter.next();
@@ -305,6 +306,43 @@ class Permissions {
             denyGroups.put(perm.get_PermissionSource(), perm.get_GranteeName());
           }
         }
+      }
+    }
+
+    @SuppressWarnings("deprecation")  // For PermissionSource.MARKING
+    /** Builds an ACL from Marking Permissions. */
+    private Acl(int constraintMask) {
+      Iterator<?> iter = perms.iterator();
+      while (iter.hasNext()) {
+        AccessPermission perm = (AccessPermission) iter.next();
+        int mask = perm.get_AccessMask();
+        if ((mask & USE_MARKING) != USE_MARKING) {
+          continue;
+        }
+        if (perm.get_AccessType() == AccessType.ALLOW) {
+          if (perm.get_GranteeType() == SecurityPrincipalType.USER) {
+            allowUsers.put(PermissionSource.MARKING, perm.get_GranteeName());
+          } else {
+            allowGroups.put(PermissionSource.MARKING, perm.get_GranteeName());
+          }
+        } else {
+          if (perm.get_GranteeType() == SecurityPrincipalType.USER) {
+            denyUsers.put(PermissionSource.MARKING, perm.get_GranteeName());
+          } else {
+            denyGroups.put(PermissionSource.MARKING, perm.get_GranteeName());
+          }
+        }
+      }
+      boolean authorizeByConstraints =
+          (VIEW_ACCESS_RIGHTS & ~constraintMask) == VIEW_ACCESS_RIGHTS;
+      if (authorizeByConstraints) {
+        allowGroups.put(PermissionSource.MARKING, AUTHENTICATED_USERS);
+      } else {
+        // If we added a denyGroups of AUTHENTICATED_USERS, the ACL would
+        // end up denying everybody, since the GSA ACL model would not reflect
+        // how use rights trump the constraint mask. However, AND_BOTH_PERMIT
+        // allows this to work itself out, since anyone not explicitly
+        // granted ALLOW rights, would be denied anyway.
       }
     }
 

--- a/src/com/google/enterprise/adaptor/filenet/Permissions.java
+++ b/src/com/google/enterprise/adaptor/filenet/Permissions.java
@@ -336,11 +336,13 @@ class Permissions {
       boolean authorizeByConstraints =
           (VIEW_ACCESS_RIGHTS & ~constraintMask) == VIEW_ACCESS_RIGHTS;
       if (authorizeByConstraints) {
+        // TODO(bmj): AUTHENTICATED_USERS should really be feed as a local
+        // group, not a global group.
         allowGroups.put(PermissionSource.MARKING, AUTHENTICATED_USERS);
       } else {
         // If we added a denyGroups of AUTHENTICATED_USERS, the ACL would
         // end up denying everybody, since the ACL chain would not reflect
-        // how use rights trump the constraint mask. However, AND_BOTH_PERMIT
+        // how Use rights trump the constraint mask. However, AND_BOTH_PERMIT
         // allows this to work itself out, since anyone not explicitly
         // granted ALLOW rights, will be denied anyway.
       }

--- a/test/com/google/enterprise/adaptor/filenet/DocumentTraverserTest.java
+++ b/test/com/google/enterprise/adaptor/filenet/DocumentTraverserTest.java
@@ -430,8 +430,6 @@ public class DocumentTraverserTest {
     String markingId2 = "{AAAAAAAA-0002-0000-0000-000000000000}";
     DocId docId = newDocId(new Id(id));
     MockObjectStore os = getObjectStore();
-    int markingAccessMask = AccessRight.USE_MARKING_AS_INT
-        | AccessRight.READ_AS_INT | AccessRight.VIEW_CONTENT_AS_INT;
 
     mockDocument(os, id, DOCUMENT_TIMESTAMP, true,
         1000d, "text/plain",
@@ -441,14 +439,11 @@ public class DocumentTraverserTest {
             PermissionSource.SOURCE_PARENT),
         new ActiveMarkingListMock(
             mockActiveMarking("marking1", markingId1,
-                AccessLevel.FULL_CONTROL_AS_INT,
-                TestObjectFactory.newPermissionList(
-                    TestObjectFactory.generatePermissions(1, 1, 1, 1,
-                        markingAccessMask, 0, PermissionSource.MARKING))),
-            mockActiveMarking("marking2", markingId2, AccessRight.READ_AS_INT,
-                TestObjectFactory.newPermissionList(
-                    TestObjectFactory.generatePermissions(1, 1, 1, 1,
-                        markingAccessMask, 0, PermissionSource.MARKING)))));
+                TestObjectFactory.getMarkingPermissions(),
+                AccessLevel.FULL_CONTROL_AS_INT),
+            mockActiveMarking("marking2", markingId2,
+                TestObjectFactory.getMarkingPermissions(),
+                AccessRight.READ_AS_INT)));
 
     DocumentTraverser traverser = new DocumentTraverser(options);
     Request request = new MockRequest(docId);

--- a/test/com/google/enterprise/adaptor/filenet/DocumentTraverserTest.java
+++ b/test/com/google/enterprise/adaptor/filenet/DocumentTraverserTest.java
@@ -43,6 +43,8 @@ import com.google.enterprise.adaptor.filenet.FileNetProxies.MockObjectStore;
 import com.google.enterprise.adaptor.testing.RecordingDocIdPusher;
 import com.google.enterprise.adaptor.testing.RecordingResponse;
 
+import com.filenet.api.constants.AccessLevel;
+import com.filenet.api.constants.AccessRight;
 import com.filenet.api.constants.PermissionSource;
 import com.filenet.api.constants.PropertyNames;
 import com.filenet.api.util.Id;
@@ -428,6 +430,8 @@ public class DocumentTraverserTest {
     String markingId2 = "{AAAAAAAA-0002-0000-0000-000000000000}";
     DocId docId = newDocId(new Id(id));
     MockObjectStore os = getObjectStore();
+    int markingAccessMask = AccessRight.USE_MARKING_AS_INT
+        | AccessRight.READ_AS_INT | AccessRight.VIEW_CONTENT_AS_INT;
 
     mockDocument(os, id, DOCUMENT_TIMESTAMP, true,
         1000d, "text/plain",
@@ -437,9 +441,14 @@ public class DocumentTraverserTest {
             PermissionSource.SOURCE_PARENT),
         new ActiveMarkingListMock(
             mockActiveMarking("marking1", markingId1,
-                TestObjectFactory.getPermissions(PermissionSource.MARKING)),
-            mockActiveMarking("marking2", markingId2,
-                TestObjectFactory.getPermissions(PermissionSource.MARKING))));
+                AccessLevel.FULL_CONTROL_AS_INT,
+                TestObjectFactory.newPermissionList(
+                    TestObjectFactory.generatePermissions(1, 1, 1, 1,
+                        markingAccessMask, 0, PermissionSource.MARKING))),
+            mockActiveMarking("marking2", markingId2, AccessRight.READ_AS_INT,
+                TestObjectFactory.newPermissionList(
+                    TestObjectFactory.generatePermissions(1, 1, 1, 1,
+                        markingAccessMask, 0, PermissionSource.MARKING)))));
 
     DocumentTraverser traverser = new DocumentTraverser(options);
     Request request = new MockRequest(docId);

--- a/test/com/google/enterprise/adaptor/filenet/ObjectMocks.java
+++ b/test/com/google/enterprise/adaptor/filenet/ObjectMocks.java
@@ -177,11 +177,11 @@ class ObjectMocks {
    * and Permissions.
    */
   public static ActiveMarking mockActiveMarking(String name,
-      String guid, Integer constraintMask, AccessPermissionList perms) {
+      String guid, AccessPermissionList perms, Integer constraintMask) {
     Marking marking = createMock(Marking.class);
     expect(marking.get_Id()).andStubReturn(newId(guid));
-    expect(marking.get_ConstraintMask()).andStubReturn(constraintMask);
     expect(marking.get_Permissions()).andStubReturn(perms);
+    expect(marking.get_ConstraintMask()).andStubReturn(constraintMask);
     ActiveMarking activeMarking = createMock(ActiveMarking.class);
     expect(activeMarking.get_Marking()).andStubReturn(marking);
     expect(activeMarking.get_PropertyDisplayName()).andStubReturn(name);

--- a/test/com/google/enterprise/adaptor/filenet/ObjectMocks.java
+++ b/test/com/google/enterprise/adaptor/filenet/ObjectMocks.java
@@ -177,9 +177,10 @@ class ObjectMocks {
    * and Permissions.
    */
   public static ActiveMarking mockActiveMarking(String name,
-      String guid, AccessPermissionList perms) {
+      String guid, Integer constraintMask, AccessPermissionList perms) {
     Marking marking = createMock(Marking.class);
     expect(marking.get_Id()).andStubReturn(newId(guid));
+    expect(marking.get_ConstraintMask()).andStubReturn(constraintMask);
     expect(marking.get_Permissions()).andStubReturn(perms);
     ActiveMarking activeMarking = createMock(ActiveMarking.class);
     expect(activeMarking.get_Marking()).andStubReturn(marking);

--- a/test/com/google/enterprise/adaptor/filenet/PermissionsTest.java
+++ b/test/com/google/enterprise/adaptor/filenet/PermissionsTest.java
@@ -701,13 +701,13 @@ public class PermissionsTest {
     Permissions testPerms = new Permissions(new AccessPermissionListMock());
     Permissions.Acl acl = testPerms.getMarkingAcl(~VIEW_ACCESS_RIGHTS);
 
-    assertEquals(ImmutableSet.<String>of(AUTHENTICATED_USERS),
+    assertEquals(ImmutableSet.of(AUTHENTICATED_USERS),
         acl.getAllowGroups(PermissionSource.MARKING));
-    assertEquals(ImmutableSet.<String>of(AUTHENTICATED_USERS),
+    assertEquals(ImmutableSet.of(AUTHENTICATED_USERS),
         acl.getAllowGroups());
-    assertEquals(ImmutableSet.<String>of(), acl.getAllowUsers());
-    assertEquals(ImmutableSet.<String>of(), acl.getDenyUsers());
-    assertEquals(ImmutableSet.<String>of(), acl.getDenyGroups());
+    assertEquals(ImmutableSet.of(), acl.getAllowUsers());
+    assertEquals(ImmutableSet.of(), acl.getDenyUsers());
+    assertEquals(ImmutableSet.of(), acl.getDenyGroups());
   }
 
   @Test
@@ -715,10 +715,10 @@ public class PermissionsTest {
     Permissions testPerms = new Permissions(new AccessPermissionListMock());
     Permissions.Acl acl = testPerms.getMarkingAcl(VIEW_ACCESS_RIGHTS);
 
-    assertEquals(ImmutableSet.<String>of(), acl.getAllowUsers());
-    assertEquals(ImmutableSet.<String>of(), acl.getAllowGroups());
-    assertEquals(ImmutableSet.<String>of(), acl.getDenyUsers());
-    assertEquals(ImmutableSet.<String>of(), acl.getDenyGroups());
+    assertEquals(ImmutableSet.of(), acl.getAllowUsers());
+    assertEquals(ImmutableSet.of(), acl.getAllowGroups());
+    assertEquals(ImmutableSet.of(), acl.getDenyUsers());
+    assertEquals(ImmutableSet.of(), acl.getDenyGroups());
   }
 
   @Test
@@ -726,10 +726,10 @@ public class PermissionsTest {
     Permissions testPerms = new Permissions(new AccessPermissionListMock());
     Permissions.Acl acl = testPerms.getMarkingAcl(~AccessRight.READ_AS_INT);
 
-    assertEquals(ImmutableSet.<String>of(), acl.getAllowUsers());
-    assertEquals(ImmutableSet.<String>of(), acl.getAllowGroups());
-    assertEquals(ImmutableSet.<String>of(), acl.getDenyUsers());
-    assertEquals(ImmutableSet.<String>of(), acl.getDenyGroups());
+    assertEquals(ImmutableSet.of(), acl.getAllowUsers());
+    assertEquals(ImmutableSet.of(), acl.getAllowGroups());
+    assertEquals(ImmutableSet.of(), acl.getDenyUsers());
+    assertEquals(ImmutableSet.of(), acl.getDenyGroups());
   }
 
   @SuppressWarnings("deprecation")  // For PermissionSource.MARKING
@@ -740,13 +740,13 @@ public class PermissionsTest {
         TestObjectFactory.getPermissions(PermissionSource.MARKING));
     Permissions.Acl acl = testPerms.getMarkingAcl(~VIEW_ACCESS_RIGHTS);
 
-    assertEquals(ImmutableSet.<String>of(AUTHENTICATED_USERS),
+    assertEquals(ImmutableSet.of(AUTHENTICATED_USERS),
         acl.getAllowGroups(PermissionSource.MARKING));
-    assertEquals(ImmutableSet.<String>of(AUTHENTICATED_USERS),
+    assertEquals(ImmutableSet.of(AUTHENTICATED_USERS),
         acl.getAllowGroups());
-    assertEquals(ImmutableSet.<String>of(), acl.getAllowUsers());
-    assertEquals(ImmutableSet.<String>of(), acl.getDenyUsers());
-    assertEquals(ImmutableSet.<String>of(), acl.getDenyGroups());
+    assertEquals(ImmutableSet.of(), acl.getAllowUsers());
+    assertEquals(ImmutableSet.of(), acl.getDenyUsers());
+    assertEquals(ImmutableSet.of(), acl.getDenyGroups());
   }
 
   @SuppressWarnings("deprecation")  // For PermissionSource.MARKING
@@ -757,10 +757,10 @@ public class PermissionsTest {
         TestObjectFactory.getPermissions(PermissionSource.MARKING));
     Permissions.Acl acl = testPerms.getMarkingAcl(VIEW_ACCESS_RIGHTS);
 
-    assertEquals(ImmutableSet.<String>of(), acl.getAllowUsers());
-    assertEquals(ImmutableSet.<String>of(), acl.getAllowGroups());
-    assertEquals(ImmutableSet.<String>of(), acl.getDenyUsers());
-    assertEquals(ImmutableSet.<String>of(), acl.getDenyGroups());
+    assertEquals(ImmutableSet.of(), acl.getAllowUsers());
+    assertEquals(ImmutableSet.of(), acl.getAllowGroups());
+    assertEquals(ImmutableSet.of(), acl.getDenyUsers());
+    assertEquals(ImmutableSet.of(), acl.getDenyGroups());
   }
 
   @SuppressWarnings("deprecation")  // For PermissionSource.MARKING
@@ -771,10 +771,10 @@ public class PermissionsTest {
         TestObjectFactory.getPermissions(PermissionSource.MARKING));
     Permissions.Acl acl = testPerms.getMarkingAcl(~AccessRight.READ_AS_INT);
 
-    assertEquals(ImmutableSet.<String>of(), acl.getAllowUsers());
-    assertEquals(ImmutableSet.<String>of(), acl.getAllowGroups());
-    assertEquals(ImmutableSet.<String>of(), acl.getDenyUsers());
-    assertEquals(ImmutableSet.<String>of(), acl.getDenyGroups());
+    assertEquals(ImmutableSet.of(), acl.getAllowUsers());
+    assertEquals(ImmutableSet.of(), acl.getAllowGroups());
+    assertEquals(ImmutableSet.of(), acl.getDenyUsers());
+    assertEquals(ImmutableSet.of(), acl.getDenyGroups());
   }
 
   @SuppressWarnings("deprecation")  // For PermissionSource.MARKING
@@ -788,16 +788,16 @@ public class PermissionsTest {
     Permissions.Acl acl = testPerms.getMarkingAcl(~VIEW_ACCESS_RIGHTS);
 
     assertEquals(
-        ImmutableSet.<String>of("MARKING_allow_user_0", "MARKING_allow_user_1"),
+        ImmutableSet.of("MARKING_allow_user_0", "MARKING_allow_user_1"),
         acl.getAllowUsers());
     assertEquals(
-        ImmutableSet.<String>of("MARKING_allow_group_0", AUTHENTICATED_USERS),
+        ImmutableSet.of("MARKING_allow_group_0", AUTHENTICATED_USERS),
         acl.getAllowGroups());
     assertEquals(
-        ImmutableSet.<String>of("MARKING_deny_user_0", "MARKING_deny_user_1"),
+        ImmutableSet.of("MARKING_deny_user_0", "MARKING_deny_user_1"),
         acl.getDenyUsers());
     assertEquals(
-        ImmutableSet.<String>of("MARKING_deny_group_0", "MARKING_deny_group_1"),
+        ImmutableSet.of("MARKING_deny_group_0", "MARKING_deny_group_1"),
         acl.getDenyGroups());
   }
 
@@ -812,16 +812,15 @@ public class PermissionsTest {
     Permissions.Acl acl = testPerms.getMarkingAcl(VIEW_ACCESS_RIGHTS);
 
     assertEquals(
-        ImmutableSet.<String>of("MARKING_allow_user_0", "MARKING_allow_user_1"),
+        ImmutableSet.of("MARKING_allow_user_0", "MARKING_allow_user_1"),
         acl.getAllowUsers());
-    assertEquals(
-        ImmutableSet.<String>of("MARKING_allow_group_0"),
+    assertEquals(ImmutableSet.of("MARKING_allow_group_0"),
         acl.getAllowGroups());
     assertEquals(
-        ImmutableSet.<String>of("MARKING_deny_user_0", "MARKING_deny_user_1"),
+        ImmutableSet.of("MARKING_deny_user_0", "MARKING_deny_user_1"),
         acl.getDenyUsers());
     assertEquals(
-        ImmutableSet.<String>of("MARKING_deny_group_0", "MARKING_deny_group_1"),
+        ImmutableSet.of("MARKING_deny_group_0", "MARKING_deny_group_1"),
         acl.getDenyGroups());
   }
 
@@ -836,16 +835,14 @@ public class PermissionsTest {
     Permissions.Acl acl = testPerms.getMarkingAcl(AccessRight.READ_AS_INT);
 
     assertEquals(
-        ImmutableSet.<String>of("MARKING_allow_user_0", "MARKING_allow_user_1"),
+        ImmutableSet.of("MARKING_allow_user_0", "MARKING_allow_user_1"),
         acl.getAllowUsers());
-    assertEquals(
-        ImmutableSet.<String>of("MARKING_allow_group_0"),
+    assertEquals(ImmutableSet.of("MARKING_allow_group_0"),
         acl.getAllowGroups());
-    assertEquals(
-        ImmutableSet.<String>of("MARKING_deny_user_0", "MARKING_deny_user_1"),
+    assertEquals(ImmutableSet.of("MARKING_deny_user_0", "MARKING_deny_user_1"),
         acl.getDenyUsers());
     assertEquals(
-        ImmutableSet.<String>of("MARKING_deny_group_0", "MARKING_deny_group_1"),
+        ImmutableSet.of("MARKING_deny_group_0", "MARKING_deny_group_1"),
         acl.getDenyGroups());
   }
 
@@ -873,18 +870,11 @@ public class PermissionsTest {
     Permissions testPerms = new Permissions(perms);
     Permissions.Acl acl = testPerms.getMarkingAcl(~VIEW_ACCESS_RIGHTS);
 
-    assertEquals(
-        ImmutableSet.<String>of("allowUser1"),
-        acl.getAllowUsers());
-    assertEquals(
-        ImmutableSet.<String>of("allowGroup2", AUTHENTICATED_USERS),
+    assertEquals(ImmutableSet.of("allowUser1"), acl.getAllowUsers());
+    assertEquals(ImmutableSet.of("allowGroup2", AUTHENTICATED_USERS),
         acl.getAllowGroups());
-    assertEquals(
-        ImmutableSet.<String>of("denyUser2"),
-        acl.getDenyUsers());
-    assertEquals(
-        ImmutableSet.<String>of("denyGroup1"),
-        acl.getDenyGroups());
+    assertEquals(ImmutableSet.of("denyUser2"), acl.getDenyUsers());
+    assertEquals(ImmutableSet.of("denyGroup1"), acl.getDenyGroups());
   }
 
   @SuppressWarnings("deprecation")  // For PermissionSource.MARKING
@@ -911,17 +901,11 @@ public class PermissionsTest {
     Permissions testPerms = new Permissions(perms);
     Permissions.Acl acl = testPerms.getMarkingAcl(VIEW_ACCESS_RIGHTS);
 
-    assertEquals(
-        ImmutableSet.<String>of("allowUser1", "allowUser2"),
+    assertEquals(ImmutableSet.of("allowUser1", "allowUser2"),
         acl.getAllowUsers());
-    assertEquals(
-        ImmutableSet.<String>of("allowGroup2"),
-        acl.getAllowGroups());
-    assertEquals(
-        ImmutableSet.<String>of("denyUser2"),
-        acl.getDenyUsers());
-    assertEquals(
-        ImmutableSet.<String>of("denyGroup1", "denyGroup2"),
+    assertEquals(ImmutableSet.of("allowGroup2"), acl.getAllowGroups());
+    assertEquals(ImmutableSet.of("denyUser2"), acl.getDenyUsers());
+    assertEquals(ImmutableSet.of("denyGroup1", "denyGroup2"),
         acl.getDenyGroups());
   }
 
@@ -949,17 +933,11 @@ public class PermissionsTest {
     Permissions testPerms = new Permissions(perms);
     Permissions.Acl acl = testPerms.getMarkingAcl(AccessRight.READ_AS_INT);
 
-    assertEquals(
-        ImmutableSet.<String>of("allowUser1", "allowUser2"),
+    assertEquals(ImmutableSet.of("allowUser1", "allowUser2"),
         acl.getAllowUsers());
-    assertEquals(
-        ImmutableSet.<String>of("allowGroup2"),
-        acl.getAllowGroups());
-    assertEquals(
-        ImmutableSet.<String>of("denyUser2"),
-        acl.getDenyUsers());
-    assertEquals(
-        ImmutableSet.<String>of("denyGroup1", "denyGroup2"),
+    assertEquals(ImmutableSet.of("allowGroup2"), acl.getAllowGroups());
+    assertEquals(ImmutableSet.of("denyUser2"), acl.getDenyUsers());
+    assertEquals(ImmutableSet.of("denyGroup1", "denyGroup2"),
         acl.getDenyGroups());
   }
 }

--- a/test/com/google/enterprise/adaptor/filenet/PermissionsTest.java
+++ b/test/com/google/enterprise/adaptor/filenet/PermissionsTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.enterprise.adaptor.filenet.EngineCollectionMocks.AccessPermissionListMock;
 
 import com.filenet.api.constants.AccessLevel;
@@ -40,6 +41,8 @@ import java.util.Set;
 
 /** Tests the Permissions utility class. */
 public class PermissionsTest {
+
+  private static final String AUTHENTICATED_USERS = "#AUTHENTICATED-USERS";
   private static final int VIEW_ACCESS_RIGHTS =
       AccessRight.READ_AS_INT | AccessRight.VIEW_CONTENT_AS_INT;
 
@@ -690,5 +693,276 @@ public class PermissionsTest {
     testMarking(AccessType.ALLOW, VIEW_ACCESS_RIGHTS,
         SecurityPrincipalType.USER, "user2@bar.example.com", user1, false,
         AccessRight.NONE);
+  }
+
+  //======================================================================
+
+  @SuppressWarnings("deprecation")  // For PermissionSource.MARKING
+  @Test
+  public void testMarkingAcl_emptyAcl_allowConstraintMask() throws Exception {
+    Permissions testPerms = new Permissions(perms);
+    Permissions.Acl acl = testPerms.getMarkingAcl(~VIEW_ACCESS_RIGHTS);
+
+    assertEquals(ImmutableSet.<String>of(AUTHENTICATED_USERS),
+        acl.getAllowGroups(PermissionSource.MARKING));
+    assertEquals(ImmutableSet.<String>of(AUTHENTICATED_USERS),
+        acl.getAllowGroups());
+    assertTrue(acl.getAllowUsers().toString(), acl.getAllowUsers().isEmpty());
+    assertTrue(acl.getDenyUsers().toString(), acl.getDenyUsers().isEmpty());
+    assertTrue(acl.getDenyGroups().toString(), acl.getDenyGroups().isEmpty());
+  }
+
+  @Test
+  public void testMarkingAcl_emptyAcl_denyConstraintMask() throws Exception {
+    Permissions testPerms = new Permissions(perms);
+    Permissions.Acl acl = testPerms.getMarkingAcl(VIEW_ACCESS_RIGHTS);
+
+    assertTrue(acl.getAllowUsers().toString(), acl.getAllowUsers().isEmpty());
+    assertTrue(acl.getAllowGroups().toString(), acl.getAllowGroups().isEmpty());
+    assertTrue(acl.getDenyUsers().toString(), acl.getDenyUsers().isEmpty());
+    assertTrue(acl.getDenyGroups().toString(), acl.getDenyGroups().isEmpty());
+  }
+
+  @Test
+  public void testMarkingAcl_emptyAcl_partialConstraintMask() throws Exception {
+    Permissions testPerms = new Permissions(perms);
+    Permissions.Acl acl = testPerms.getMarkingAcl(~AccessRight.READ_AS_INT);
+
+    assertTrue(acl.getAllowUsers().toString(), acl.getAllowUsers().isEmpty());
+    assertTrue(acl.getAllowGroups().toString(), acl.getAllowGroups().isEmpty());
+    assertTrue(acl.getDenyUsers().toString(), acl.getDenyUsers().isEmpty());
+    assertTrue(acl.getDenyGroups().toString(), acl.getDenyGroups().isEmpty());
+  }
+
+  @SuppressWarnings("deprecation")  // For PermissionSource.MARKING
+  @Test
+  public void testMarkingAcl_noUseMarking_allowConstraintMask()
+      throws Exception {
+    Permissions testPerms = new Permissions(
+        TestObjectFactory.getPermissions(PermissionSource.MARKING));
+    Permissions.Acl acl = testPerms.getMarkingAcl(~VIEW_ACCESS_RIGHTS);
+
+    assertEquals(ImmutableSet.<String>of(AUTHENTICATED_USERS),
+        acl.getAllowGroups(PermissionSource.MARKING));
+    assertEquals(ImmutableSet.<String>of(AUTHENTICATED_USERS),
+        acl.getAllowGroups());
+    assertTrue(acl.getAllowUsers().toString(), acl.getAllowUsers().isEmpty());
+    assertTrue(acl.getDenyUsers().toString(), acl.getDenyUsers().isEmpty());
+    assertTrue(acl.getDenyGroups().toString(), acl.getDenyGroups().isEmpty());
+  }
+
+  @SuppressWarnings("deprecation")  // For PermissionSource.MARKING
+  @Test
+  public void testMarkingAcl_noUseMarking_denyConstraintMask()
+      throws Exception {
+    Permissions testPerms = new Permissions(
+        TestObjectFactory.getPermissions(PermissionSource.MARKING));
+    Permissions.Acl acl = testPerms.getMarkingAcl(VIEW_ACCESS_RIGHTS);
+
+    assertTrue(acl.getAllowUsers().toString(), acl.getAllowUsers().isEmpty());
+    assertTrue(acl.getAllowGroups().toString(), acl.getAllowGroups().isEmpty());
+    assertTrue(acl.getDenyUsers().toString(), acl.getDenyUsers().isEmpty());
+    assertTrue(acl.getDenyGroups().toString(), acl.getDenyGroups().isEmpty());
+  }
+
+  @SuppressWarnings("deprecation")  // For PermissionSource.MARKING
+  @Test
+  public void testMarkingAcl_noUseMarking_partialConstraintMask()
+      throws Exception {
+    Permissions testPerms = new Permissions(
+        TestObjectFactory.getPermissions(PermissionSource.MARKING));
+    Permissions.Acl acl = testPerms.getMarkingAcl(~AccessRight.READ_AS_INT);
+
+    assertTrue(acl.getAllowUsers().toString(), acl.getAllowUsers().isEmpty());
+    assertTrue(acl.getAllowGroups().toString(), acl.getAllowGroups().isEmpty());
+    assertTrue(acl.getDenyUsers().toString(), acl.getDenyUsers().isEmpty());
+    assertTrue(acl.getDenyGroups().toString(), acl.getDenyGroups().isEmpty());
+  }
+
+
+  @SuppressWarnings("deprecation")  // For PermissionSource.MARKING
+  @Test
+  public void testMarkingAcl_allUseMarking_allowConstraintMask()
+      throws Exception {
+    Permissions testPerms = new Permissions(
+        TestObjectFactory.newPermissionList(
+            TestObjectFactory.generatePermissions(2, 2, 1, 2,
+                AccessRight.USE_MARKING_AS_INT, 0, PermissionSource.MARKING)));
+    Permissions.Acl acl = testPerms.getMarkingAcl(~VIEW_ACCESS_RIGHTS);
+
+    assertEquals(
+        ImmutableSet.<String>of("MARKING_allow_user_0", "MARKING_allow_user_1"),
+        acl.getAllowUsers());
+    assertEquals(
+        ImmutableSet.<String>of("MARKING_allow_group_0", AUTHENTICATED_USERS),
+        acl.getAllowGroups());
+    assertEquals(
+        ImmutableSet.<String>of("MARKING_deny_user_0", "MARKING_deny_user_1"),
+        acl.getDenyUsers());
+    assertEquals(
+        ImmutableSet.<String>of("MARKING_deny_group_0", "MARKING_deny_group_1"),
+        acl.getDenyGroups());
+  }
+
+  @SuppressWarnings("deprecation")  // For PermissionSource.MARKING
+  @Test
+  public void testMarkingAcl_allUseMarking_denyConstraintMask()
+      throws Exception {
+    Permissions testPerms = new Permissions(
+        TestObjectFactory.newPermissionList(
+            TestObjectFactory.generatePermissions(2, 2, 1, 2,
+                AccessRight.USE_MARKING_AS_INT, 0, PermissionSource.MARKING)));
+    Permissions.Acl acl = testPerms.getMarkingAcl(VIEW_ACCESS_RIGHTS);
+
+    assertEquals(
+        ImmutableSet.<String>of("MARKING_allow_user_0", "MARKING_allow_user_1"),
+        acl.getAllowUsers());
+    assertEquals(
+        ImmutableSet.<String>of("MARKING_allow_group_0"),
+        acl.getAllowGroups());
+    assertEquals(
+        ImmutableSet.<String>of("MARKING_deny_user_0", "MARKING_deny_user_1"),
+        acl.getDenyUsers());
+    assertEquals(
+        ImmutableSet.<String>of("MARKING_deny_group_0", "MARKING_deny_group_1"),
+        acl.getDenyGroups());
+  }
+
+  @SuppressWarnings("deprecation")  // For PermissionSource.MARKING
+  @Test
+  public void testMarkingAcl_allUseMarking_partialConstraintMask()
+      throws Exception {
+    Permissions testPerms = new Permissions(
+        TestObjectFactory.newPermissionList(
+            TestObjectFactory.generatePermissions(2, 2, 1, 2,
+                AccessRight.USE_MARKING_AS_INT, 0, PermissionSource.MARKING)));
+    Permissions.Acl acl = testPerms.getMarkingAcl(AccessRight.READ_AS_INT);
+
+    assertEquals(
+        ImmutableSet.<String>of("MARKING_allow_user_0", "MARKING_allow_user_1"),
+        acl.getAllowUsers());
+    assertEquals(
+        ImmutableSet.<String>of("MARKING_allow_group_0"),
+        acl.getAllowGroups());
+    assertEquals(
+        ImmutableSet.<String>of("MARKING_deny_user_0", "MARKING_deny_user_1"),
+        acl.getDenyUsers());
+    assertEquals(
+        ImmutableSet.<String>of("MARKING_deny_group_0", "MARKING_deny_group_1"),
+        acl.getDenyGroups());
+  }
+
+  @SuppressWarnings("deprecation")  // For PermissionSource.MARKING
+  @Test
+  public void testMarkingAcl_someUseMarking_allowConstraintMask()
+      throws Exception {
+    addAce(PermissionSource.MARKING, SecurityPrincipalType.USER,
+        AccessType.ALLOW, AccessRight.USE_MARKING_AS_INT, 0, "allowUser1");
+    addAce(PermissionSource.MARKING, SecurityPrincipalType.USER,
+        AccessType.ALLOW, 0, 0, "allowUser2");
+    addAce(PermissionSource.MARKING, SecurityPrincipalType.GROUP,
+        AccessType.ALLOW, 0, 0, "allowGroup1");
+    addAce(PermissionSource.MARKING, SecurityPrincipalType.GROUP,
+        AccessType.ALLOW, AccessRight.USE_MARKING_AS_INT, 0, "allowGroup2");
+    addAce(PermissionSource.MARKING, SecurityPrincipalType.USER,
+        AccessType.DENY, 0, 0, "denyUser1");
+    addAce(PermissionSource.MARKING, SecurityPrincipalType.USER,
+        AccessType.DENY, AccessRight.USE_MARKING_AS_INT, 0, "denyUser2");
+    addAce(PermissionSource.MARKING, SecurityPrincipalType.GROUP,
+        AccessType.DENY, AccessRight.USE_MARKING_AS_INT, 0, "denyGroup1");
+    addAce(PermissionSource.MARKING, SecurityPrincipalType.GROUP,
+        AccessType.DENY, 0, 0, "denyGroup2");
+
+    Permissions testPerms = new Permissions(perms);
+    Permissions.Acl acl = testPerms.getMarkingAcl(~VIEW_ACCESS_RIGHTS);
+
+    assertEquals(
+        ImmutableSet.<String>of("allowUser1"),
+        acl.getAllowUsers());
+    assertEquals(
+        ImmutableSet.<String>of("allowGroup2", AUTHENTICATED_USERS),
+        acl.getAllowGroups());
+    assertEquals(
+        ImmutableSet.<String>of("denyUser2"),
+        acl.getDenyUsers());
+    assertEquals(
+        ImmutableSet.<String>of("denyGroup1"),
+        acl.getDenyGroups());
+  }
+
+  @SuppressWarnings("deprecation")  // For PermissionSource.MARKING
+  @Test
+  public void testMarkingAcl_someUseMarking_denyConstraintMask()
+      throws Exception {
+    addAce(PermissionSource.MARKING, SecurityPrincipalType.USER,
+        AccessType.ALLOW, AccessRight.USE_MARKING_AS_INT, 0, "allowUser1");
+    addAce(PermissionSource.MARKING, SecurityPrincipalType.USER,
+           AccessType.ALLOW, AccessRight.USE_MARKING_AS_INT, 0, "allowUser2");
+    addAce(PermissionSource.MARKING, SecurityPrincipalType.GROUP,
+        AccessType.ALLOW, 0, 0, "allowGroup1");
+    addAce(PermissionSource.MARKING, SecurityPrincipalType.GROUP,
+        AccessType.ALLOW, AccessRight.USE_MARKING_AS_INT, 0, "allowGroup2");
+    addAce(PermissionSource.MARKING, SecurityPrincipalType.USER,
+        AccessType.DENY, 0, 0, "denyUser1");
+    addAce(PermissionSource.MARKING, SecurityPrincipalType.USER,
+        AccessType.DENY, AccessRight.USE_MARKING_AS_INT, 0, "denyUser2");
+    addAce(PermissionSource.MARKING, SecurityPrincipalType.GROUP,
+        AccessType.DENY, AccessRight.USE_MARKING_AS_INT, 0, "denyGroup1");
+    addAce(PermissionSource.MARKING, SecurityPrincipalType.GROUP,
+        AccessType.DENY, AccessRight.USE_MARKING_AS_INT, 0, "denyGroup2");
+
+    Permissions testPerms = new Permissions(perms);
+    Permissions.Acl acl = testPerms.getMarkingAcl(VIEW_ACCESS_RIGHTS);
+
+    assertEquals(
+        ImmutableSet.<String>of("allowUser1", "allowUser2"),
+        acl.getAllowUsers());
+    assertEquals(
+        ImmutableSet.<String>of("allowGroup2"),
+        acl.getAllowGroups());
+    assertEquals(
+        ImmutableSet.<String>of("denyUser2"),
+        acl.getDenyUsers());
+    assertEquals(
+        ImmutableSet.<String>of("denyGroup1", "denyGroup2"),
+        acl.getDenyGroups());
+  }
+
+  @SuppressWarnings("deprecation")  // For PermissionSource.MARKING
+  @Test
+  public void testMarkingAcl_someUseMarking_partialConstraintMask()
+      throws Exception {
+    addAce(PermissionSource.MARKING, SecurityPrincipalType.USER,
+        AccessType.ALLOW, AccessRight.USE_MARKING_AS_INT, 0, "allowUser1");
+    addAce(PermissionSource.MARKING, SecurityPrincipalType.USER,
+           AccessType.ALLOW, AccessRight.USE_MARKING_AS_INT, 0, "allowUser2");
+    addAce(PermissionSource.MARKING, SecurityPrincipalType.GROUP,
+        AccessType.ALLOW, 0, 0, "allowGroup1");
+    addAce(PermissionSource.MARKING, SecurityPrincipalType.GROUP,
+        AccessType.ALLOW, AccessRight.USE_MARKING_AS_INT, 0, "allowGroup2");
+    addAce(PermissionSource.MARKING, SecurityPrincipalType.USER,
+        AccessType.DENY, 0, 0, "denyUser1");
+    addAce(PermissionSource.MARKING, SecurityPrincipalType.USER,
+        AccessType.DENY, AccessRight.USE_MARKING_AS_INT, 0, "denyUser2");
+    addAce(PermissionSource.MARKING, SecurityPrincipalType.GROUP,
+        AccessType.DENY, AccessRight.USE_MARKING_AS_INT, 0, "denyGroup1");
+    addAce(PermissionSource.MARKING, SecurityPrincipalType.GROUP,
+        AccessType.DENY, AccessRight.USE_MARKING_AS_INT, 0, "denyGroup2");
+
+    Permissions testPerms = new Permissions(perms);
+    Permissions.Acl acl = testPerms.getMarkingAcl(AccessRight.READ_AS_INT);
+
+    assertEquals(
+        ImmutableSet.<String>of("allowUser1", "allowUser2"),
+        acl.getAllowUsers());
+    assertEquals(
+        ImmutableSet.<String>of("allowGroup2"),
+        acl.getAllowGroups());
+    assertEquals(
+        ImmutableSet.<String>of("denyUser2"),
+        acl.getDenyUsers());
+    assertEquals(
+        ImmutableSet.<String>of("denyGroup1", "denyGroup2"),
+        acl.getDenyGroups());
   }
 }

--- a/test/com/google/enterprise/adaptor/filenet/PermissionsTest.java
+++ b/test/com/google/enterprise/adaptor/filenet/PermissionsTest.java
@@ -14,6 +14,8 @@
 
 package com.google.enterprise.adaptor.filenet;
 
+import static com.google.enterprise.adaptor.filenet.Permissions.AUTHENTICATED_USERS;
+import static com.google.enterprise.adaptor.filenet.Permissions.VIEW_ACCESS_RIGHTS;
 import static com.google.enterprise.adaptor.filenet.SecurityPrincipalMocks.DOMAIN;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -41,10 +43,6 @@ import java.util.Set;
 
 /** Tests the Permissions utility class. */
 public class PermissionsTest {
-
-  private static final String AUTHENTICATED_USERS = "#AUTHENTICATED-USERS";
-  private static final int VIEW_ACCESS_RIGHTS =
-      AccessRight.READ_AS_INT | AccessRight.VIEW_CONTENT_AS_INT;
 
   private AccessPermissionListMock perms;
   private User user;
@@ -700,38 +698,38 @@ public class PermissionsTest {
   @SuppressWarnings("deprecation")  // For PermissionSource.MARKING
   @Test
   public void testMarkingAcl_emptyAcl_allowConstraintMask() throws Exception {
-    Permissions testPerms = new Permissions(perms);
+    Permissions testPerms = new Permissions(new AccessPermissionListMock());
     Permissions.Acl acl = testPerms.getMarkingAcl(~VIEW_ACCESS_RIGHTS);
 
     assertEquals(ImmutableSet.<String>of(AUTHENTICATED_USERS),
         acl.getAllowGroups(PermissionSource.MARKING));
     assertEquals(ImmutableSet.<String>of(AUTHENTICATED_USERS),
         acl.getAllowGroups());
-    assertTrue(acl.getAllowUsers().toString(), acl.getAllowUsers().isEmpty());
-    assertTrue(acl.getDenyUsers().toString(), acl.getDenyUsers().isEmpty());
-    assertTrue(acl.getDenyGroups().toString(), acl.getDenyGroups().isEmpty());
+    assertEquals(ImmutableSet.<String>of(), acl.getAllowUsers());
+    assertEquals(ImmutableSet.<String>of(), acl.getDenyUsers());
+    assertEquals(ImmutableSet.<String>of(), acl.getDenyGroups());
   }
 
   @Test
   public void testMarkingAcl_emptyAcl_denyConstraintMask() throws Exception {
-    Permissions testPerms = new Permissions(perms);
+    Permissions testPerms = new Permissions(new AccessPermissionListMock());
     Permissions.Acl acl = testPerms.getMarkingAcl(VIEW_ACCESS_RIGHTS);
 
-    assertTrue(acl.getAllowUsers().toString(), acl.getAllowUsers().isEmpty());
-    assertTrue(acl.getAllowGroups().toString(), acl.getAllowGroups().isEmpty());
-    assertTrue(acl.getDenyUsers().toString(), acl.getDenyUsers().isEmpty());
-    assertTrue(acl.getDenyGroups().toString(), acl.getDenyGroups().isEmpty());
+    assertEquals(ImmutableSet.<String>of(), acl.getAllowUsers());
+    assertEquals(ImmutableSet.<String>of(), acl.getAllowGroups());
+    assertEquals(ImmutableSet.<String>of(), acl.getDenyUsers());
+    assertEquals(ImmutableSet.<String>of(), acl.getDenyGroups());
   }
 
   @Test
   public void testMarkingAcl_emptyAcl_partialConstraintMask() throws Exception {
-    Permissions testPerms = new Permissions(perms);
+    Permissions testPerms = new Permissions(new AccessPermissionListMock());
     Permissions.Acl acl = testPerms.getMarkingAcl(~AccessRight.READ_AS_INT);
 
-    assertTrue(acl.getAllowUsers().toString(), acl.getAllowUsers().isEmpty());
-    assertTrue(acl.getAllowGroups().toString(), acl.getAllowGroups().isEmpty());
-    assertTrue(acl.getDenyUsers().toString(), acl.getDenyUsers().isEmpty());
-    assertTrue(acl.getDenyGroups().toString(), acl.getDenyGroups().isEmpty());
+    assertEquals(ImmutableSet.<String>of(), acl.getAllowUsers());
+    assertEquals(ImmutableSet.<String>of(), acl.getAllowGroups());
+    assertEquals(ImmutableSet.<String>of(), acl.getDenyUsers());
+    assertEquals(ImmutableSet.<String>of(), acl.getDenyGroups());
   }
 
   @SuppressWarnings("deprecation")  // For PermissionSource.MARKING
@@ -746,9 +744,9 @@ public class PermissionsTest {
         acl.getAllowGroups(PermissionSource.MARKING));
     assertEquals(ImmutableSet.<String>of(AUTHENTICATED_USERS),
         acl.getAllowGroups());
-    assertTrue(acl.getAllowUsers().toString(), acl.getAllowUsers().isEmpty());
-    assertTrue(acl.getDenyUsers().toString(), acl.getDenyUsers().isEmpty());
-    assertTrue(acl.getDenyGroups().toString(), acl.getDenyGroups().isEmpty());
+    assertEquals(ImmutableSet.<String>of(), acl.getAllowUsers());
+    assertEquals(ImmutableSet.<String>of(), acl.getDenyUsers());
+    assertEquals(ImmutableSet.<String>of(), acl.getDenyGroups());
   }
 
   @SuppressWarnings("deprecation")  // For PermissionSource.MARKING
@@ -759,10 +757,10 @@ public class PermissionsTest {
         TestObjectFactory.getPermissions(PermissionSource.MARKING));
     Permissions.Acl acl = testPerms.getMarkingAcl(VIEW_ACCESS_RIGHTS);
 
-    assertTrue(acl.getAllowUsers().toString(), acl.getAllowUsers().isEmpty());
-    assertTrue(acl.getAllowGroups().toString(), acl.getAllowGroups().isEmpty());
-    assertTrue(acl.getDenyUsers().toString(), acl.getDenyUsers().isEmpty());
-    assertTrue(acl.getDenyGroups().toString(), acl.getDenyGroups().isEmpty());
+    assertEquals(ImmutableSet.<String>of(), acl.getAllowUsers());
+    assertEquals(ImmutableSet.<String>of(), acl.getAllowGroups());
+    assertEquals(ImmutableSet.<String>of(), acl.getDenyUsers());
+    assertEquals(ImmutableSet.<String>of(), acl.getDenyGroups());
   }
 
   @SuppressWarnings("deprecation")  // For PermissionSource.MARKING
@@ -773,12 +771,11 @@ public class PermissionsTest {
         TestObjectFactory.getPermissions(PermissionSource.MARKING));
     Permissions.Acl acl = testPerms.getMarkingAcl(~AccessRight.READ_AS_INT);
 
-    assertTrue(acl.getAllowUsers().toString(), acl.getAllowUsers().isEmpty());
-    assertTrue(acl.getAllowGroups().toString(), acl.getAllowGroups().isEmpty());
-    assertTrue(acl.getDenyUsers().toString(), acl.getDenyUsers().isEmpty());
-    assertTrue(acl.getDenyGroups().toString(), acl.getDenyGroups().isEmpty());
+    assertEquals(ImmutableSet.<String>of(), acl.getAllowUsers());
+    assertEquals(ImmutableSet.<String>of(), acl.getAllowGroups());
+    assertEquals(ImmutableSet.<String>of(), acl.getDenyUsers());
+    assertEquals(ImmutableSet.<String>of(), acl.getDenyGroups());
   }
-
 
   @SuppressWarnings("deprecation")  // For PermissionSource.MARKING
   @Test
@@ -859,19 +856,19 @@ public class PermissionsTest {
     addAce(PermissionSource.MARKING, SecurityPrincipalType.USER,
         AccessType.ALLOW, AccessRight.USE_MARKING_AS_INT, 0, "allowUser1");
     addAce(PermissionSource.MARKING, SecurityPrincipalType.USER,
-        AccessType.ALLOW, 0, 0, "allowUser2");
+        AccessType.ALLOW, AccessRight.NONE_AS_INT, 0, "allowUser2");
     addAce(PermissionSource.MARKING, SecurityPrincipalType.GROUP,
-        AccessType.ALLOW, 0, 0, "allowGroup1");
+        AccessType.ALLOW, AccessRight.NONE_AS_INT, 0, "allowGroup1");
     addAce(PermissionSource.MARKING, SecurityPrincipalType.GROUP,
         AccessType.ALLOW, AccessRight.USE_MARKING_AS_INT, 0, "allowGroup2");
     addAce(PermissionSource.MARKING, SecurityPrincipalType.USER,
-        AccessType.DENY, 0, 0, "denyUser1");
+        AccessType.DENY, VIEW_ACCESS_RIGHTS, 0, "denyUser1");
     addAce(PermissionSource.MARKING, SecurityPrincipalType.USER,
         AccessType.DENY, AccessRight.USE_MARKING_AS_INT, 0, "denyUser2");
     addAce(PermissionSource.MARKING, SecurityPrincipalType.GROUP,
         AccessType.DENY, AccessRight.USE_MARKING_AS_INT, 0, "denyGroup1");
     addAce(PermissionSource.MARKING, SecurityPrincipalType.GROUP,
-        AccessType.DENY, 0, 0, "denyGroup2");
+        AccessType.DENY, AccessRight.NONE_AS_INT, 0, "denyGroup2");
 
     Permissions testPerms = new Permissions(perms);
     Permissions.Acl acl = testPerms.getMarkingAcl(~VIEW_ACCESS_RIGHTS);
@@ -897,13 +894,13 @@ public class PermissionsTest {
     addAce(PermissionSource.MARKING, SecurityPrincipalType.USER,
         AccessType.ALLOW, AccessRight.USE_MARKING_AS_INT, 0, "allowUser1");
     addAce(PermissionSource.MARKING, SecurityPrincipalType.USER,
-           AccessType.ALLOW, AccessRight.USE_MARKING_AS_INT, 0, "allowUser2");
+        AccessType.ALLOW, AccessRight.USE_MARKING_AS_INT, 0, "allowUser2");
     addAce(PermissionSource.MARKING, SecurityPrincipalType.GROUP,
-        AccessType.ALLOW, 0, 0, "allowGroup1");
+        AccessType.ALLOW, AccessRight.NONE_AS_INT, 0, "allowGroup1");
     addAce(PermissionSource.MARKING, SecurityPrincipalType.GROUP,
         AccessType.ALLOW, AccessRight.USE_MARKING_AS_INT, 0, "allowGroup2");
     addAce(PermissionSource.MARKING, SecurityPrincipalType.USER,
-        AccessType.DENY, 0, 0, "denyUser1");
+        AccessType.DENY, VIEW_ACCESS_RIGHTS, 0, "denyUser1");
     addAce(PermissionSource.MARKING, SecurityPrincipalType.USER,
         AccessType.DENY, AccessRight.USE_MARKING_AS_INT, 0, "denyUser2");
     addAce(PermissionSource.MARKING, SecurityPrincipalType.GROUP,
@@ -937,11 +934,11 @@ public class PermissionsTest {
     addAce(PermissionSource.MARKING, SecurityPrincipalType.USER,
            AccessType.ALLOW, AccessRight.USE_MARKING_AS_INT, 0, "allowUser2");
     addAce(PermissionSource.MARKING, SecurityPrincipalType.GROUP,
-        AccessType.ALLOW, 0, 0, "allowGroup1");
+        AccessType.ALLOW, VIEW_ACCESS_RIGHTS, 0, "allowGroup1");
     addAce(PermissionSource.MARKING, SecurityPrincipalType.GROUP,
         AccessType.ALLOW, AccessRight.USE_MARKING_AS_INT, 0, "allowGroup2");
     addAce(PermissionSource.MARKING, SecurityPrincipalType.USER,
-        AccessType.DENY, 0, 0, "denyUser1");
+        AccessType.DENY, AccessRight.NONE_AS_INT, 0, "denyUser1");
     addAce(PermissionSource.MARKING, SecurityPrincipalType.USER,
         AccessType.DENY, AccessRight.USE_MARKING_AS_INT, 0, "denyUser2");
     addAce(PermissionSource.MARKING, SecurityPrincipalType.GROUP,

--- a/test/com/google/enterprise/adaptor/filenet/PermissionsTest.java
+++ b/test/com/google/enterprise/adaptor/filenet/PermissionsTest.java
@@ -782,22 +782,17 @@ public class PermissionsTest {
   public void testMarkingAcl_allUseMarking_allowConstraintMask()
       throws Exception {
     Permissions testPerms = new Permissions(
-        TestObjectFactory.newPermissionList(
-            TestObjectFactory.generatePermissions(2, 2, 1, 2,
-                AccessRight.USE_MARKING_AS_INT, 0, PermissionSource.MARKING)));
+        TestObjectFactory.getMarkingPermissions());
     Permissions.Acl acl = testPerms.getMarkingAcl(~VIEW_ACCESS_RIGHTS);
 
-    assertEquals(
-        ImmutableSet.of("MARKING_allow_user_0", "MARKING_allow_user_1"),
+    assertEquals(ImmutableSet.of("MARKING_allow_user_0"),
         acl.getAllowUsers());
     assertEquals(
         ImmutableSet.of("MARKING_allow_group_0", AUTHENTICATED_USERS),
         acl.getAllowGroups());
-    assertEquals(
-        ImmutableSet.of("MARKING_deny_user_0", "MARKING_deny_user_1"),
+    assertEquals(ImmutableSet.of("MARKING_deny_user_0"),
         acl.getDenyUsers());
-    assertEquals(
-        ImmutableSet.of("MARKING_deny_group_0", "MARKING_deny_group_1"),
+    assertEquals(ImmutableSet.of("MARKING_deny_group_0"),
         acl.getDenyGroups());
   }
 
@@ -806,21 +801,16 @@ public class PermissionsTest {
   public void testMarkingAcl_allUseMarking_denyConstraintMask()
       throws Exception {
     Permissions testPerms = new Permissions(
-        TestObjectFactory.newPermissionList(
-            TestObjectFactory.generatePermissions(2, 2, 1, 2,
-                AccessRight.USE_MARKING_AS_INT, 0, PermissionSource.MARKING)));
+        TestObjectFactory.getMarkingPermissions());
     Permissions.Acl acl = testPerms.getMarkingAcl(VIEW_ACCESS_RIGHTS);
 
-    assertEquals(
-        ImmutableSet.of("MARKING_allow_user_0", "MARKING_allow_user_1"),
+    assertEquals(ImmutableSet.of("MARKING_allow_user_0"),
         acl.getAllowUsers());
     assertEquals(ImmutableSet.of("MARKING_allow_group_0"),
         acl.getAllowGroups());
-    assertEquals(
-        ImmutableSet.of("MARKING_deny_user_0", "MARKING_deny_user_1"),
+    assertEquals(ImmutableSet.of("MARKING_deny_user_0"),
         acl.getDenyUsers());
-    assertEquals(
-        ImmutableSet.of("MARKING_deny_group_0", "MARKING_deny_group_1"),
+    assertEquals(ImmutableSet.of("MARKING_deny_group_0"),
         acl.getDenyGroups());
   }
 
@@ -829,20 +819,16 @@ public class PermissionsTest {
   public void testMarkingAcl_allUseMarking_partialConstraintMask()
       throws Exception {
     Permissions testPerms = new Permissions(
-        TestObjectFactory.newPermissionList(
-            TestObjectFactory.generatePermissions(2, 2, 1, 2,
-                AccessRight.USE_MARKING_AS_INT, 0, PermissionSource.MARKING)));
+        TestObjectFactory.getMarkingPermissions());
     Permissions.Acl acl = testPerms.getMarkingAcl(AccessRight.READ_AS_INT);
 
-    assertEquals(
-        ImmutableSet.of("MARKING_allow_user_0", "MARKING_allow_user_1"),
+    assertEquals(ImmutableSet.of("MARKING_allow_user_0"),
         acl.getAllowUsers());
     assertEquals(ImmutableSet.of("MARKING_allow_group_0"),
         acl.getAllowGroups());
-    assertEquals(ImmutableSet.of("MARKING_deny_user_0", "MARKING_deny_user_1"),
+    assertEquals(ImmutableSet.of("MARKING_deny_user_0"),
         acl.getDenyUsers());
-    assertEquals(
-        ImmutableSet.of("MARKING_deny_group_0", "MARKING_deny_group_1"),
+    assertEquals(ImmutableSet.of("MARKING_deny_group_0"),
         acl.getDenyGroups());
   }
 

--- a/test/com/google/enterprise/adaptor/filenet/TestObjectFactory.java
+++ b/test/com/google/enterprise/adaptor/filenet/TestObjectFactory.java
@@ -61,6 +61,13 @@ class TestObjectFactory {
     return new ConfigOptions(config, SENSITIVE_VALUE_DECODER);
   }
 
+  @SuppressWarnings("deprecation")  // For PermissionSource.MARKING
+  public static AccessPermissionList getMarkingPermissions() {
+    return newPermissionList(
+        generatePermissions(1, 1, 1, 1, AccessRight.USE_MARKING_AS_INT, 0,
+            PermissionSource.MARKING));
+  }
+
   public static AccessPermissionList getPermissions(
       PermissionSource... sources) {
     List<AccessPermission> aces = new ArrayList<>();


### PR DESCRIPTION
- Pay attention to USE_MARKING when collecting ACEs
- Apply constraint mask when not ALLOWed or DENYed by USE_MARKING
- Do not replicate 2 bugs that are in authorizeMarking:
  - Incorrect use of constraint mask when collecting DENY ACEs
  - ALLOW by constraint mask should preserve both READ and VIEW
    access rights bits