### PR TITLE
Switch from Document ID to VersionSeries ID for the DocId.

### DIFF
--- a/src/com/google/enterprise/adaptor/filenet/DocumentTraverser.java
+++ b/src/com/google/enterprise/adaptor/filenet/DocumentTraverser.java
@@ -30,7 +30,6 @@ import com.google.enterprise.adaptor.filenet.FileNetAdaptor.Checkpoint;
 
 import com.filenet.api.collection.ActiveMarkingList;
 import com.filenet.api.collection.IndependentObjectSet;
-import com.filenet.api.constants.ClassNames;
 import com.filenet.api.constants.GuidConstants;
 import com.filenet.api.constants.PermissionSource;
 import com.filenet.api.constants.PropertyNames;
@@ -108,7 +107,7 @@ class DocumentTraverser implements FileNetAdaptor.Traverser {
           query);
       IndependentObjectSet objectSet = search.fetchObjects(query,
           maxRecords, SearchWrapper.dereferenceObjects,
-          SearchWrapper.ALL_ROWS);
+          SearchWrapper.CONTINUABLE);
       logger.fine(objectSet.isEmpty()
           ? "Found no documents to add or update"
           : "Found documents to add or update");
@@ -120,8 +119,11 @@ class DocumentTraverser implements FileNetAdaptor.Traverser {
       while (objects.hasNext()) {
         Document object = (Document) objects.next();
         timestamp = object.get_DateLastModified();
-        guid = object.get_Id(); // TODO: Use the VersionSeries ID.
-        records.add(new DocIdPusher.Record.Builder(newDocId(guid)).build());
+        guid = object.get_Id();
+        Id vsId = object.get_VersionSeries().get_Id();
+        logger.log(Level.FINER, "Document ID: {0}", guid);
+        logger.log(Level.FINER, "VersionSeries ID: {0}", vsId);
+        records.add(new DocIdPusher.Record.Builder(newDocId(vsId)).build());
       }
       // TODO(jlacey): if (records.size() == maxRecords)
       if (timestamp != null) {
@@ -153,7 +155,7 @@ class DocumentTraverser implements FileNetAdaptor.Traverser {
     query.append(",");
     query.append(PropertyNames.DATE_LAST_MODIFIED);
     query.append(",");
-    query.append(PropertyNames.RELEASED_VERSION);
+    query.append(PropertyNames.VERSION_SERIES);
     query.append(" FROM ");
     query.append(GuidConstants.Class_Document);
     query.append(" WHERE VersionStatus=1 and ContentSize IS NOT NULL ");
@@ -203,30 +205,61 @@ class DocumentTraverser implements FileNetAdaptor.Traverser {
   }
 
   @Override
-  public void getDocContent(Id guid, Request request, Response response)
+  public void getDocContent(Id vsId, Request request, Response response)
       throws IOException {
     try (AutoConnection connection = options.getConnection()) {
       ObjectStore objectStore = options.getObjectStore(connection);
       logger.log(Level.FINE, "Target ObjectStore is: {0}", objectStore);
 
-      Document document = (Document)
-          objectStore.fetchObject(ClassNames.DOCUMENT, guid,
+      ObjectFactory objectFactory = options.getObjectFactory();
+      SearchWrapper search = objectFactory.getSearch(objectStore);
+
+      String query = "SELECT Id FROM Document"
+          + " WHERE VersionSeries = OBJECT(" + vsId + ") and VersionStatus = 1";
+      IndependentObjectSet objectSet = search.fetchObjects(query, null,
+          SearchWrapper.NO_FILTER, SearchWrapper.NOT_CONTINUABLE);
+      Iterator<?> objects = objectSet.iterator();
+      if (objects.hasNext()) {
+        Document document = (Document) objects.next();
+        Id guid = document.get_Id();
+        logger.log(Level.FINE, "Found document ID {0} for VersionSeries ID {1}",
+            new Object[] { guid, vsId });
+        try {
+          document.refresh(
               FileUtil.getDocumentPropertyFilter(
                   options.getIncludedMetadata(),
                   options.getExcludedMetadata()));
+        } catch (EngineRuntimeException e) {
+          // This inner try statement just avoids returning 404 if the
+          // object store is not found (returning 500 instead).
+          if (e.getExceptionCode() == ExceptionCode.E_OBJECT_NOT_FOUND) {
+            logger.log(Level.FINE, "Unable to fetch document for ID {0}", guid);
+            response.respondNotFound();
+            return;
+          } else {
+            throw e;
+          }
+        }
 
-      logger.log(Level.FINEST, "Add document [ID: {0}]", guid);
-      processDocument(guid, newDocId(guid), document, request, response);
+        processDocument(newDocId(vsId), vsId, guid, document,
+            request, response);
+
+        if (objects.hasNext()) {
+          logger.log(Level.INFO,
+              "Duplicate released documents for VersionSeries ID: {0}", vsId);
+        }
+      } else {
+        logger.log(Level.FINE, "VersionSeries not found for ID {0}", vsId);
+        response.respondNotFound();
+      }
     } catch (EngineRuntimeException e) {
       throw new IOException(e);
     }
   }
 
-  private void processDocument(Id guid, DocId docId, Document document,
+  private void processDocument(DocId docId, Id vsId, Id guid, Document document,
       Request request, Response response) throws IOException {
-    logger.log(Level.FINE, "Fetch document for DocId {0}", guid);
-    String vsDocId = document.get_VersionSeries().get_Id().toString();
-    logger.log(Level.FINE, "VersionSeriesID for document is: {0}", vsDocId);
+    logger.log(Level.FINE, "Process document for ID: {0}", guid);
 
     if (!options.markAllDocsAsPublic()) {
       ActiveMarkingList activeMarkings = document.get_ActiveMarkings();
@@ -238,7 +271,7 @@ class DocumentTraverser implements FileNetAdaptor.Traverser {
 
     response.setContentType(document.get_MimeType());
     response.setDisplayUrl(
-        URI.create(options.getDisplayUrl() + percentEscape(vsDocId)));
+        URI.create(options.getDisplayUrl() + percentEscape(vsId.toString())));
     response.setLastModified(document.get_DateLastModified());
 
     setMetadata(document, response);

--- a/src/com/google/enterprise/adaptor/filenet/DocumentTraverser.java
+++ b/src/com/google/enterprise/adaptor/filenet/DocumentTraverser.java
@@ -69,9 +69,10 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Responsible for: 1. Construction of FileNet SQL queries for adding and
- * deleting index of documents to GSA. 2. Execution of the SQL query constructed
- * in step 1. 3. Retrieve the results of step 2 and wrap it in DocumentList
+ * Fetches batches of documents from checkpoints, and individual
+ * documents given their VersionSeries ID. The VersionSeries ID is
+ * used instead of the Document ID because it remains the same for all
+ * versions of a document.
  */
 class DocumentTraverser implements FileNetAdaptor.Traverser {
   private static final Logger logger =

--- a/src/com/google/enterprise/adaptor/filenet/FileUtil.java
+++ b/src/com/google/enterprise/adaptor/filenet/FileUtil.java
@@ -51,7 +51,6 @@ class FileUtil {
     filterSet.add(PropertyNames.MIME_TYPE);
     filterSet.add(PropertyNames.VERSION_SERIES);
     filterSet.add(PropertyNames.VERSION_SERIES_ID);
-    filterSet.add(PropertyNames.RELEASED_VERSION);
     filterSet.add(PropertyNames.OWNER);
     filterSet.add(PropertyNames.ACTIVE_MARKINGS);
     filterSet.add(PropertyNames.PERMISSIONS);

--- a/src/com/google/enterprise/adaptor/filenet/SearchWrapper.java
+++ b/src/com/google/enterprise/adaptor/filenet/SearchWrapper.java
@@ -38,14 +38,11 @@ class SearchWrapper {
   /** Do not filter the results or deference object properties. */
   public static final PropertyFilter NO_FILTER = null;
 
-  /** Return all results. */
-  public static final Boolean ALL_ROWS = Boolean.TRUE;
+  /** Page through larger, sorted results. */
+  public static final Boolean CONTINUABLE = Boolean.TRUE;
 
-  /**
-   * Return a single page of results, which might be less than the
-   * page size.
-   */
-  public static final Boolean FIRST_ROWS = Boolean.FALSE;
+  /** Do not page through small or unsorted results. */
+  public static final Boolean NOT_CONTINUABLE = Boolean.FALSE;
 
   static {
     dereferenceObjects.setMaxRecursion(1);

--- a/test/com/google/enterprise/adaptor/filenet/DocumentTraverserTest.java
+++ b/test/com/google/enterprise/adaptor/filenet/DocumentTraverserTest.java
@@ -20,6 +20,7 @@ import static com.google.enterprise.adaptor.filenet.FileNetAdaptor.Checkpoint.ge
 import static com.google.enterprise.adaptor.filenet.FileNetAdaptor.newDocId;
 import static com.google.enterprise.adaptor.filenet.ObjectMocks.mockActiveMarking;
 import static com.google.enterprise.adaptor.filenet.ObjectMocks.mockDocument;
+import static com.google.enterprise.adaptor.filenet.ObjectMocks.mockDocumentNotFound;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.junit.Assert.assertEquals;
@@ -450,6 +451,43 @@ public class DocumentTraverserTest {
     assertNotNull(response.getAcl());
     assertFalse(response.getNamedResources().isEmpty());
     assertEquals(RecordingResponse.State.NO_CONTENT, response.getState());
+    assertEquals(0, baos.size());
+  }
+
+  @Test
+  public void testGetDocContent_notFound_fetchObjects() throws Exception {
+    String id = "{AAAAAAAA-0000-0000-0000-000000000000}";
+    DocId docId = newDocId(new Id(id));
+    MockObjectStore os = getObjectStore();
+
+    DocumentTraverser traverser = new DocumentTraverser(options);
+    Request request = new MockRequest(docId, new Date());
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    RecordingResponse response = new RecordingResponse(baos);
+    traverser.getDocContent(new Id(id), request, response);
+
+    assertNull(response.getAcl());
+    assertTrue(response.getNamedResources().isEmpty());
+    assertEquals(RecordingResponse.State.NOT_FOUND, response.getState());
+    assertEquals(0, baos.size());
+  }
+
+  @Test
+  public void testGetDocContent_notFound_refresh() throws Exception {
+    String id = "{AAAAAAAA-0000-0000-0000-000000000000}";
+    DocId docId = newDocId(new Id(id));
+    MockObjectStore os = getObjectStore();
+    mockDocumentNotFound(os, id);
+
+    DocumentTraverser traverser = new DocumentTraverser(options);
+    Request request = new MockRequest(docId, new Date());
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    RecordingResponse response = new RecordingResponse(baos);
+    traverser.getDocContent(new Id(id), request, response);
+
+    assertNull(response.getAcl());
+    assertTrue(response.getNamedResources().isEmpty());
+    assertEquals(RecordingResponse.State.NOT_FOUND, response.getState());
     assertEquals(0, baos.size());
   }
 

--- a/test/com/google/enterprise/adaptor/filenet/ObjectMocks.java
+++ b/test/com/google/enterprise/adaptor/filenet/ObjectMocks.java
@@ -15,6 +15,7 @@
 package com.google.enterprise.adaptor.filenet;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.eq;
 import static org.easymock.EasyMock.expect;
@@ -35,9 +36,11 @@ import com.filenet.api.core.ObjectStore;
 import com.filenet.api.core.VersionSeries;
 import com.filenet.api.events.DeletionEvent;
 import com.filenet.api.exception.EngineRuntimeException;
+import com.filenet.api.exception.ExceptionCode;
 import com.filenet.api.property.Properties;
 import com.filenet.api.property.Property;
 import com.filenet.api.property.PropertyDateTime;
+import com.filenet.api.property.PropertyFilter;
 import com.filenet.api.property.PropertyFloat64;
 import com.filenet.api.property.PropertyId;
 import com.filenet.api.property.PropertyString;
@@ -151,6 +154,8 @@ class ObjectMocks {
     expect(properties.toArray()).andStubReturn(props);
 
     Document doc = createMock(Document.class);
+    doc.refresh(anyObject(PropertyFilter.class));
+    expectLastCall().asStub();
     expect(doc.get_Id()).andStubReturn(newId(guid));
     expect(doc.get_VersionSeries()).andStubReturn(vs);
     expect(doc.get_DateLastModified()).andStubReturn(parseTime(timeStr));
@@ -168,6 +173,18 @@ class ObjectMocks {
     expect(doc.get_ActiveMarkings()).andStubReturn(activeMarkings);
     expect(doc.getProperties()).andStubReturn(properties);
     replay(vs, properties, doc);
+    objectStore.addObject(doc);
+    return doc;
+  }
+
+  public static Document mockDocumentNotFound(MockObjectStore objectStore,
+      String guid) {
+    Document doc = createMock(Document.class);
+    doc.refresh(anyObject(PropertyFilter.class));
+    expectLastCall().andThrow(
+        new EngineRuntimeException(ExceptionCode.E_OBJECT_NOT_FOUND));
+    expect(doc.get_Id()).andStubReturn(newId(guid));
+    replay(doc);
     objectStore.addObject(doc);
     return doc;
   }


### PR DESCRIPTION
Add respondNotFound to getDocContent since we are querying for the
document by VersionSeries ID in any case. Borrow some code from #27.

Related changes:

* Rename misleading SearchWrapper continuable constants.
* Make SearchMock smart enough to return individual objects.

Other changes:

* Remove intentionally unused MockObjectStore.containsObject method.
  Testing missing objects through the production code is preferred.