### PR TITLE
Remove dead code from Permissions

### DIFF
--- a/src/com/google/enterprise/adaptor/filenet/Permissions.java
+++ b/src/com/google/enterprise/adaptor/filenet/Permissions.java
@@ -18,49 +18,20 @@ import com.google.common.collect.HashMultimap;
 import com.google.common.collect.SetMultimap;
 
 import com.filenet.api.collection.AccessPermissionList;
-import com.filenet.api.constants.AccessLevel;
 import com.filenet.api.constants.AccessRight;
 import com.filenet.api.constants.AccessType;
 import com.filenet.api.constants.PermissionSource;
 import com.filenet.api.constants.SecurityPrincipalType;
 import com.filenet.api.security.AccessPermission;
-import com.filenet.api.security.Group;
-import com.filenet.api.security.User;
 
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
- * Wrapper class over the FileNet API class Permissions. This class is
- * responsible to authorize a target user against all the Access Control Entries
- * of a target document.
+ * Wrapper class over the FileNet API class Permissions.
  */
 class Permissions {
-  private static final Logger LOGGER =
-      Logger.getLogger(Permissions.class.getName());
-
-  public static interface Factory {
-    Permissions getInstance(AccessPermissionList perms, String owner);
-    Permissions getInstance(AccessPermissionList perms);
-  }
-
-  public static Factory getFactory() {
-    return new Factory() {
-      @Override
-      public Permissions getInstance(AccessPermissionList perms, String owner) {
-        return new Permissions(perms, owner);
-      }
-
-      @Override
-      public Permissions getInstance(AccessPermissionList perms) {
-        return getInstance(perms, null);
-      }
-    };
-  }
-
   public static final String AUTHENTICATED_USERS = "#AUTHENTICATED-USERS";
   private static final String CREATOR_OWNER = "#CREATOR-OWNER";
 
@@ -78,191 +49,6 @@ class Permissions {
 
   public Permissions(AccessPermissionList perms) {
     this(perms, null);
-  }
-
-  /**
-   * To authorize a given username against the grantee-names, present in all
-   * the Access Control Entries for all the permission of the target document.
-   *
-   * @param Username which needs to be authorized.
-   * @return True or False, depending on the success or failure of
-   *         authorization.
-   */
-  public boolean authorize(User user) {
-    boolean isAuthorized = false;
-    Iterator<?> iter = perms.iterator();
-
-    LOGGER.log(Level.FINE, "Authorizing user:[" + user.get_Name() + "]");
-
-    while (iter.hasNext()) {
-      try {
-        AccessPermission perm = (AccessPermission) iter.next();
-        Integer accessMask = perm.get_AccessMask();
-        LOGGER.log(Level.FINEST, "Access Mask is:[" + accessMask + "]");
-
-        if (AccessType.DENY.equals(perm.get_AccessType())) {
-          // Checking for denied read or view content rights.  If either one is
-          // true and user is a member of the ACE, the user is not authorized.
-          if ((VIEW_ACCESS_RIGHTS & accessMask) != 0
-              && matchesUser(perm, user)) {
-            LOGGER.log(Level.FINEST,
-                "Access is denied for user {0} via grantee {1}",
-                new Object[] {user.get_Name(), perm.get_GranteeName()});
-            return false;
-          }
-        } else {
-          // Compare to make sure that the access level, to user for a
-          // document, is at least view or above
-          if ((VIEW_ACCESS_RIGHTS & accessMask) == VIEW_ACCESS_RIGHTS
-              && isAuthorized == false && matchesUser(perm, user)) {
-            isAuthorized = true;
-          }
-        }
-      } catch (Exception ecp) {
-        LOGGER.log(Level.WARNING,
-            "Exception occured in authorizing user against permissions. "
-            + ecp.getMessage(), ecp);
-      }
-    }
-
-    LOGGER.log(Level.FINEST, "User [{0}] is {1}authorized to access document",
-        new Object[] {user.get_Name(), (isAuthorized) ? "" : "not "});
-    return isAuthorized;
-  }
-
-  /**
-   * To check, a given user has at least USE right or above, over all the
-   * marking permission of the target document.
-   *
-   * @param Username which needs to be authorized.
-   * @return True or False, depending on the success or failure of check for
-   *         USE right.
-   * @see com.google.enterprise.adaptor.filenet.IPermissions#authorizeMarking(java.lang.String)
-   */
-  public boolean authorizeMarking(User user, Integer constraintMask) {
-    boolean hasUseRight = false;
-
-    Iterator<?> iter = perms.iterator();
-    while (iter.hasNext()) {
-      try {
-        AccessPermission perm = (AccessPermission) iter.next();
-        LOGGER.log(Level.FINEST, "Checking access rights for {0} user: "
-            + "grantee[{1}], access mask[{2}], constraint mask[{3}]",
-            new Object[] {user.get_Name(), perm.get_GranteeName(),
-                perm.get_AccessMask(), constraintMask});
-
-        if ((perm.get_AccessMask() & USE_MARKING) == USE_MARKING) {
-          if (hasUseRight == false
-              && AccessType.ALLOW.equals(perm.get_AccessType())
-              && matchesUser(perm, user)) {
-            hasUseRight = true;
-          } else if (AccessType.DENY.equals(perm.get_AccessType())
-              && (AccessLevel.FULL_CONTROL_AS_INT == constraintMask)
-              && matchesUser(perm, user)) {
-            LOGGER.log(Level.FINE, "User: [{0}] has Deny USE right and Deny "
-                + "all access rights over the document", user.get_Name());
-            return false;
-          }
-        }
-      } catch (Exception ecp) {
-        LOGGER.log(Level.WARNING, "Exception occurred in authorizing user "
-            + "against permissions. " + ecp.getMessage(), ecp);
-      }
-    }
-    if (hasUseRight) {
-      LOGGER.log(Level.FINE, "User [{0}] has USE right over the document",
-          user.get_Name());
-      return true;
-    } else {
-      boolean authorizeByConstraints =
-          (VIEW_ACCESS_RIGHTS & constraintMask) == 0;
-      LOGGER.log(Level.FINE, "User [{0}] is {1}authorized by constraints",
-          new Object[] {user.get_Name(),
-              (authorizeByConstraints ? "" : "not ")});
-      return authorizeByConstraints;
-    }
-  }
-
-  private boolean matchesAnyString(String name, String... otherNames) {
-    for (String otherName : otherNames) {
-      if (name.equalsIgnoreCase(otherName)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  /**
-   * To check, a given user is in the list of Grantee of the given permission
-   * object.
-   *
-   * @param Object of the AccessPermission, Search user name.
-   * @return True or False, depending on the success or failure of check for
-   *         grantee name check.
-   * @throws Exception
-   * @see com.google.enterprise.adaptor.filenet.IPermissions#checkGranteeName(AccessPermission,java.lang.String)
-   */
-  private boolean matchesUser(AccessPermission perm, User user) {
-    String granteeName = perm.get_GranteeName();
-    String granteeType = perm.get_GranteeType().toString();
-    String accessType = perm.get_AccessType().toString();
-    LOGGER.log(Level.FINER, "Grantee Name: [{0}], type: {1}, access type: {2}",
-        new Object[] {granteeName, granteeType, accessType});
-
-    if (perm.get_GranteeType() == SecurityPrincipalType.USER) {
-      if (granteeName.equalsIgnoreCase(CREATOR_OWNER)) {
-        if (owner != null && matchesAnyString(owner, user.get_Name(),
-            user.get_Email(), user.get_DistinguishedName())) {
-          LOGGER.log(Level.FINER,
-              "Authorization: [{0}] matches the creator owner",
-              user.get_Name());
-          return true;
-        }
-        LOGGER.log(Level.FINER, "Authorization [{0}]: [{1}] is not {2} owner",
-            new Object[] {accessType, user.get_Name(), owner});
-        return false;
-      }
-      if (matchesAnyString(granteeName, user.get_Name(), user.get_Email(),
-          user.get_DistinguishedName())) {
-        LOGGER.log(Level.FINER,
-            "Authorization [{0}]: [{1}] grantee matches with search user [{2}]",
-            new Object[] {accessType, granteeName, user.get_Name()});
-        return true;
-      }
-    } else if (perm.get_GranteeType() == SecurityPrincipalType.GROUP) {
-      if (granteeName.equalsIgnoreCase(AUTHENTICATED_USERS)) {
-        // #AUTHENTICATED-USERS is a logical group in
-        // FileNet P8
-        // Systems, which gets automatically
-        // created at the time of FileNet installation. This
-        // group contains all the FileNet users.
-        // This group cannot be edited by admin i.e. it is
-        // not
-        // possible to delete the user from
-        // this group. Thus every FileNet user is a part of
-        // #AUTHENTICATED-USERS group. This is the
-        // reason to authenticate a user for a document, if
-        // that
-        // document contains #AUTHENTICATED-USERS
-        // group in its ACL or ACE.
-        LOGGER.log(Level.FINER, "Authorization [{0}]: [{1}] user matches {2}",
-            new Object[] {accessType, user.get_Name(), AUTHENTICATED_USERS});
-        return true;
-      }
-
-      Iterator<?> iter = user.get_MemberOfGroups().iterator();
-      while (iter.hasNext()) {
-        Group group = (Group) iter.next();
-        if (matchesAnyString(granteeName, group.get_Name(),
-            group.get_DistinguishedName(), group.get_DisplayName())) {
-          LOGGER.log(Level.FINER,
-              "Authorization [{0}]: [{1}] user is a member of group {2}",
-              new Object[] {accessType, user.get_Name(), granteeName});
-          return true;
-        }
-      }
-    }
-    return false;
   }
 
   public Permissions.Acl getAcl() {

--- a/test/com/google/enterprise/adaptor/filenet/PermissionsTest.java
+++ b/test/com/google/enterprise/adaptor/filenet/PermissionsTest.java
@@ -16,20 +16,16 @@ package com.google.enterprise.adaptor.filenet;
 
 import static com.google.enterprise.adaptor.filenet.Permissions.AUTHENTICATED_USERS;
 import static com.google.enterprise.adaptor.filenet.Permissions.VIEW_ACCESS_RIGHTS;
-import static com.google.enterprise.adaptor.filenet.SecurityPrincipalMocks.DOMAIN;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.enterprise.adaptor.filenet.EngineCollectionMocks.AccessPermissionListMock;
 
-import com.filenet.api.constants.AccessLevel;
 import com.filenet.api.constants.AccessRight;
 import com.filenet.api.constants.AccessType;
 import com.filenet.api.constants.PermissionSource;
 import com.filenet.api.constants.SecurityPrincipalType;
-import com.filenet.api.security.Group;
 import com.filenet.api.security.User;
 
 import org.junit.After;
@@ -37,8 +33,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Collections;
-import java.util.HashSet;
-import java.util.Iterator;
 import java.util.Set;
 
 /** Tests the Permissions utility class. */
@@ -59,235 +53,6 @@ public class PermissionsTest {
   }
 
   @Test
-  public void testAllowCreatorOwnerWithViewLevel() {
-    testCreatorOwnerAccess(AccessType.ALLOW, AccessLevel.VIEW_AS_INT, true);
-  }
-
-  @Test
-  public void testAllowCreatorOwnerWithViewAccessRights() {
-    testCreatorOwnerAccess(AccessType.ALLOW, VIEW_ACCESS_RIGHTS, true);
-  }
-
-  @Test
-  public void testDenyCreatorOwner() {
-    testCreatorOwnerAccess(AccessType.DENY, VIEW_ACCESS_RIGHTS, false);
-  }
-
-  @Test
-  public void testDenyCreatorOwnerWithoutViewContentRight() {
-    testCreatorOwnerAccess(AccessType.DENY, AccessRight.READ_AS_INT, false);
-  }
-
-  @Test
-  public void testDenyCreatorOwnerWithoutReadRight() {
-    testCreatorOwnerAccess(AccessType.DENY, AccessRight.VIEW_CONTENT_AS_INT,
-        false);
-  }
-
-  @SuppressWarnings({"unchecked"})
-  private void testCreatorOwnerAccess(AccessType accessType, int accessRights,
-      boolean expectedResult) {
-    AccessPermissionMock perm =
-        new AccessPermissionMock(PermissionSource.SOURCE_DIRECT);
-    perm.set_AccessType(accessType);
-    perm.set_AccessMask(accessRights);
-    perm.set_GranteeType(SecurityPrincipalType.USER);
-    perm.set_GranteeName("#CREATOR-OWNER");
-    perms.add(perm);
-
-    Permissions testPerms = new Permissions(perms, user.get_Name());
-    assertEquals(expectedResult, testPerms.authorize(user));
-  }
-
-  @SuppressWarnings({"unchecked"})
-  @Test
-  public void testCreatorOwnerWithBothAllowAndDeny() {
-    AccessPermissionMock creatorOwnerPermDeny =
-        new AccessPermissionMock(PermissionSource.SOURCE_DIRECT);
-    creatorOwnerPermDeny.set_AccessType(AccessType.DENY);
-    creatorOwnerPermDeny.set_AccessMask(AccessRight.DELETE_AS_INT);
-    creatorOwnerPermDeny.set_GranteeType(SecurityPrincipalType.USER);
-    creatorOwnerPermDeny.set_GranteeName(user.get_Name());
-    perms.add(creatorOwnerPermDeny);
-
-    AccessPermissionMock creatorOwnerPermAllow =
-        new AccessPermissionMock(PermissionSource.SOURCE_DIRECT);
-    creatorOwnerPermAllow.set_AccessType(AccessType.ALLOW);
-    creatorOwnerPermAllow.set_AccessMask(VIEW_ACCESS_RIGHTS);
-    creatorOwnerPermAllow.set_GranteeType(SecurityPrincipalType.USER);
-    creatorOwnerPermAllow.set_GranteeName(user.get_Name());
-    perms.add(creatorOwnerPermAllow);
-
-    Permissions testPerms = new Permissions(perms, user.get_Name());
-    assertTrue(testPerms.authorize(user));
-  }
-
-  @Test
-  public void testAllowUserWithoutViewContentRight() {
-    testUserAccess(AccessType.ALLOW, AccessRight.READ_AS_INT, user, false);
-  }
-
-  @Test
-  public void testAllowUserWithoutReadRight() {
-    testUserAccess(AccessType.ALLOW, AccessRight.VIEW_CONTENT_AS_INT, user,
-        false);
-  }
-
-  @Test
-  public void testAllowUserWithoutViewRights() {
-    int accessRights = AccessRight.WRITE_OWNER_AS_INT
-        | AccessRight.WRITE_ACL_AS_INT | AccessRight.DELETE_AS_INT;
-    testUserAccess(AccessType.ALLOW, accessRights, user, false);
-  }
-
-  @Test
-  public void testDenyUserWithoutViewRights() {
-    int accessRights = AccessRight.WRITE_OWNER_AS_INT
-        | AccessRight.WRITE_ACL_AS_INT | AccessRight.DELETE_AS_INT;
-    testUserAccess(AccessType.DENY, accessRights, user, false);
-  }
-
-  private void testUserAccess(AccessType accessType, int accessRights,
-      User testUser, boolean expectedResult) {
-    testUserAccess(accessType, accessRights, testUser.get_Name(), testUser,
-        expectedResult);
-  }
-
-  private void testUserAccess(AccessType accessType, int accessRights,
-      String granteeName, User testUser, boolean expectedResult) {
-    testAccess(accessType, accessRights, SecurityPrincipalType.USER,
-        granteeName, testUser, expectedResult);
-  }
-
-  private void testGroupAccess(AccessType accessType, int accessRights,
-      String granteeName, User testUser, boolean expectedResult) {
-    testAccess(accessType, accessRights, SecurityPrincipalType.GROUP,
-        granteeName, testUser, expectedResult);
-  }
-
-  @SuppressWarnings({"unchecked"})
-  private void testAccess(AccessType accessType, int accessRights,
-      SecurityPrincipalType granteeType, String granteeName, User testUser,
-      boolean expectedResult) {
-    AccessPermissionMock perm =
-        new AccessPermissionMock(PermissionSource.SOURCE_DIRECT);
-    perm.set_AccessType(accessType);
-    perm.set_AccessMask(accessRights);
-    perm.set_GranteeType(granteeType);
-    perm.set_GranteeName(granteeName);
-    perms.add(perm);
-
-    Permissions testPerms = new Permissions(perms);
-    assertEquals(expectedResult, testPerms.authorize(testUser));
-  }
-
-  @Test
-  public void testShortName() {
-    User jsmith = SecurityPrincipalMocks.createUserWithShortName("jsmith");
-    testUserAccess(AccessType.ALLOW, VIEW_ACCESS_RIGHTS, jsmith, true);
-  }
-
-  @Test
-  public void testShortNameWithDifferentDomain() {
-    User jsmith = SecurityPrincipalMocks.createUserWithShortName("jsmith");
-    testUserAccess(AccessType.ALLOW, VIEW_ACCESS_RIGHTS, "jsmith@example.com",
-        jsmith, false);
-  }
-
-  @Test
-  public void testDistinguishedName() {
-    testUserAccess(AccessType.ALLOW, VIEW_ACCESS_RIGHTS,
-        user.get_DistinguishedName(), user, true);
-  }
-
-  @Test
-  public void testInvalidUser() {
-    User invalidUser = SecurityPrincipalMocks.createBlankUser();
-    testUserAccess(AccessType.ALLOW, VIEW_ACCESS_RIGHTS, user.get_Name(),
-        invalidUser, false);
-  }
-
-  @Test
-  public void testAuthenticatedUsers() {
-    testAccess(AccessType.ALLOW, VIEW_ACCESS_RIGHTS,
-        SecurityPrincipalType.GROUP, "#AUTHENTICATED-USERS", user, true);
-  }
-
-  @Test
-  public void testUserGroupAccess_WithDomainName() {
-    Set<String> userGroups = getGroupNames(user);
-    assertTrue(userGroups.contains("administrators@" + DOMAIN));
-    testGroupAccess(AccessType.ALLOW, VIEW_ACCESS_RIGHTS,
-        "administrators@" + DOMAIN, user, true);
-  }
-
-  @Test
-  public void testUserGroupAccess_WithShortName() {
-    Group everyone = SecurityPrincipalMocks.createEveryoneGroup();
-    assertEquals(everyone.get_ShortName(), "everyone");
-
-    User jsmith = SecurityPrincipalMocks.createUserWithShortName("jsmith");
-    assertTrue(getGroupNames(jsmith).contains(everyone.get_Name()));
-
-    testGroupAccess(AccessType.ALLOW, VIEW_ACCESS_RIGHTS,
-        everyone.get_ShortName(), jsmith, false);
-  }
-
-  @Test
-  public void testUserGroupAccess_WithDistinguishedName() {
-    Group everyone = SecurityPrincipalMocks.createEveryoneGroup();
-    assertEquals(everyone.get_DistinguishedName(),
-        SecurityPrincipalMocks.getDistinguishedName(
-            "everyone@" + DOMAIN));
-
-    User jsmith = SecurityPrincipalMocks.createUserWithShortName("jsmith");
-    assertTrue(getGroupNames(jsmith).contains(everyone.get_Name()));
-
-    testGroupAccess(AccessType.ALLOW, VIEW_ACCESS_RIGHTS,
-        everyone.get_DistinguishedName(), jsmith, true);
-  }
-
-  @SuppressWarnings({"unchecked"})
-  @Test
-  public void testUserGroupAccess_HavingBothAllowAndDeny() {
-    Set<String> userGroups = getGroupNames(user);
-    assertTrue(userGroups.contains("administrators@" + DOMAIN));
-
-    AccessPermissionMock permAllow =
-        new AccessPermissionMock(PermissionSource.SOURCE_DIRECT);
-    permAllow.set_AccessType(AccessType.ALLOW);
-    permAllow.set_AccessMask(VIEW_ACCESS_RIGHTS);
-    permAllow.set_GranteeType(SecurityPrincipalType.USER);
-    permAllow.set_GranteeName(user.get_Name());
-    perms.add(permAllow);
-
-    AccessPermissionMock permDeny =
-        new AccessPermissionMock(PermissionSource.SOURCE_DIRECT);
-    permDeny.set_AccessType(AccessType.DENY);
-    permDeny.set_AccessMask(VIEW_ACCESS_RIGHTS);
-    permDeny.set_GranteeType(SecurityPrincipalType.GROUP);
-    permDeny.set_GranteeName("administrators@" + DOMAIN);
-    perms.add(permDeny);
-
-    Permissions testPermsDenyGroup = new Permissions(perms);
-    assertFalse(testPermsDenyGroup.authorize(user));
-  }
-
-  /*
-   * TODO(jlacey): This is copied from FileAuthenticationManager, and
-   * could be moved to FileUtil and shared.
-   */
-  private Set<String> getGroupNames(User user) {
-    HashSet<String> groups = new HashSet<>();
-    Iterator<?> iter = user.get_MemberOfGroups().iterator();
-    while (iter.hasNext()) {
-      Group group = (Group) iter.next();
-      groups.add(group.get_Name());
-    }
-    return groups;
-  }
-
-  @Test
   public void testEmptyPermissionList() {
     assertEquals("Access permission list is not empty", 0, perms.size());
     Permissions.Acl emptyPerms = new Permissions(perms).getAcl();
@@ -302,19 +67,19 @@ public class PermissionsTest {
       boolean includeDenyGroups, PermissionSource permSrc) {
     if (includeAllowUsers) {
       addAces(maxPerGroup, AccessType.ALLOW, SecurityPrincipalType.USER,
-          AccessLevel.VIEW_AS_INT, 0, permSrc);
+          VIEW_ACCESS_RIGHTS, 0, permSrc);
     }
     if (includeDenyUsers) {
       addAces(maxPerGroup, AccessType.DENY, SecurityPrincipalType.USER,
-          AccessLevel.VIEW_AS_INT, 0, permSrc);
+          VIEW_ACCESS_RIGHTS, 0, permSrc);
     }
     if (includeAllowGroups) {
       addAces(maxPerGroup, AccessType.ALLOW, SecurityPrincipalType.GROUP,
-          AccessLevel.VIEW_AS_INT, 0, permSrc);
+          VIEW_ACCESS_RIGHTS, 0, permSrc);
     }
     if (includeDenyGroups) {
       addAces(maxPerGroup, AccessType.DENY, SecurityPrincipalType.GROUP,
-          AccessLevel.VIEW_AS_INT, 0, permSrc);
+          VIEW_ACCESS_RIGHTS, 0, permSrc);
     }
     Collections.shuffle(perms);
   }
@@ -389,13 +154,13 @@ public class PermissionsTest {
       int maxAllowGroups, int maxDenyUsers, int maxDenyGroups,
       PermissionSource... permSrcs) {
     addAces(maxAllowUsers, AccessType.ALLOW, SecurityPrincipalType.USER,
-        AccessLevel.VIEW_AS_INT, 0, permSrcs);
+        VIEW_ACCESS_RIGHTS, 0, permSrcs);
     addAces(maxAllowGroups, AccessType.ALLOW, SecurityPrincipalType.GROUP,
-        AccessLevel.VIEW_AS_INT, 0, permSrcs);
+        VIEW_ACCESS_RIGHTS, 0, permSrcs);
     addAces(maxDenyUsers, AccessType.DENY, SecurityPrincipalType.USER,
-        AccessLevel.VIEW_AS_INT, 0, permSrcs);
+        VIEW_ACCESS_RIGHTS, 0, permSrcs);
     addAces(maxDenyGroups, AccessType.DENY, SecurityPrincipalType.GROUP,
-        AccessLevel.VIEW_AS_INT, 0, permSrcs);
+        VIEW_ACCESS_RIGHTS, 0, permSrcs);
     Collections.shuffle(perms);
 
     return new Permissions(perms).getAcl();
@@ -506,194 +271,6 @@ public class PermissionsTest {
     assertSetContains(actualInheritDenyGroups,
         PermissionSource.SOURCE_PARENT.toString() + " deny group ", 5);
   }
-
-  // Calculate constraint mask for rights that are unchecked in the marking.
-  private int constraintMask(AccessRight... allowRights) {
-    int mask = 0;
-    for (AccessRight right : allowRights) {
-      mask |= right.getValue();
-    }
-    return constraintMask(mask);
-  }
-
-  private int constraintMask(int allowRights) {
-    return AccessLevel.FULL_CONTROL_AS_INT & ~allowRights;
-  }
-
-  private void testUserMarking(AccessType accessType, int accessMask,
-      boolean expectedResult, AccessRight... allowRights) {
-    User user1 =
-        SecurityPrincipalMocks.createUserWithDomain("user1", "foo.example.com");
-    testMarking(accessType, accessMask, SecurityPrincipalType.USER,
-        user1.get_Name(), user1, expectedResult, allowRights);
-  }
-
-  private void testMarking(AccessType accessType, int accessMask,
-      SecurityPrincipalType secType, String granteeName, User testUser,
-      boolean expectedResult, AccessRight... allowRights) {
-    testMarking(accessType, accessMask, secType, granteeName, testUser,
-        expectedResult, constraintMask(allowRights));
-  }
-
-  @SuppressWarnings({"unchecked"})
-  private void testMarking(AccessType accessType, int accessMask,
-      SecurityPrincipalType secType, String granteeName, User testUser,
-      boolean expectedResult, int constraintMask) {
-    AccessPermissionMock perm1 =
-        new AccessPermissionMock(PermissionSource.SOURCE_DIRECT);
-    perm1.set_AccessType(accessType);
-    perm1.set_AccessMask(accessMask);
-    perm1.set_GranteeType(secType);
-    perm1.set_GranteeName(granteeName);
-    perms.add(perm1);
-
-    Permissions testPerms = new Permissions(perms);
-    assertEquals(expectedResult, testPerms.authorizeMarking(testUser,
-        constraintMask));
-  }
-
-  @Test
-  public void testMarking_WithUseRight_AllowAce() {
-      testUserMarking(AccessType.ALLOW, AccessRight.USE_MARKING_AS_INT, true,
-    AccessRight.VIEW_CONTENT, AccessRight.READ);
-    testUserMarking(AccessType.ALLOW, AccessRight.USE_MARKING_AS_INT, true,
-        AccessRight.NONE);
-  }
-
-  @Test
-  public void testMarking_WithUseRight_DenyAce() {
-    testUserMarking(AccessType.DENY, AccessRight.USE_MARKING_AS_INT, true,
-        AccessRight.VIEW_CONTENT, AccessRight.READ);
-    testUserMarking(AccessType.DENY, AccessRight.USE_MARKING_AS_INT, false,
-        AccessRight.VIEW_CONTENT);
-    testUserMarking(AccessType.DENY, AccessRight.USE_MARKING_AS_INT, false,
-        AccessRight.READ);
-  }
-
-  @Test
-  public void testMarking_NoUseRight_ViewLevelConstraint() {
-    User user1 =
-        SecurityPrincipalMocks.createUserWithDomain("user1", "foo.example.com");
-    testMarking(AccessType.ALLOW, AccessRight.NONE_AS_INT,
-        SecurityPrincipalType.USER, user1.get_Name(), user1, true,
-        constraintMask(AccessLevel.VIEW_AS_INT));
-    testMarking(AccessType.DENY, AccessRight.NONE_AS_INT,
-        SecurityPrincipalType.USER, user1.get_Name(), user1, true,
-        constraintMask(AccessLevel.VIEW_AS_INT));
-  }
-
-  @Test
-  public void testMarking_NoUseRight_AllowReadViewContentRights() {
-    testUserMarking(AccessType.ALLOW, AccessRight.NONE_AS_INT, true,
-        AccessRight.VIEW_CONTENT, AccessRight.READ);
-    testUserMarking(AccessType.ALLOW, AccessRight.NONE_AS_INT, true,
-        AccessRight.VIEW_CONTENT, AccessRight.READ, AccessRight.DELETE);
-  }
-
-  @Test
-  public void testMarking_NoUseRight_MissingAllowReadViewContentRights() {
-    testUserMarking(AccessType.ALLOW, AccessRight.NONE_AS_INT, false,
-        AccessRight.VIEW_CONTENT);
-    testUserMarking(AccessType.ALLOW, AccessRight.NONE_AS_INT, false,
-        AccessRight.READ);
-  }
-
-  @Test
-  public void testMarking_NoUseRight_DenyReadViewContentRights() {
-    // Under live test, the DENY access type does not have any effects or
-    // behaves the same as ALLOW; only constraint mask matters.
-    // Testing constraint mask of read or view content rights.
-    testUserMarking(AccessType.DENY, AccessRight.NONE_AS_INT, false,
-        AccessRight.VIEW_CONTENT);
-    testUserMarking(AccessType.DENY, AccessRight.NONE_AS_INT, false,
-        AccessRight.READ);
-
-    // Testing constraint mask of both read and view content rights.
-    testUserMarking(AccessType.DENY, AccessRight.NONE_AS_INT, true,
-        AccessRight.VIEW_CONTENT, AccessRight.READ);
-  }
-
-  @Test
-  public void testMarking_NoUseRight_DenyOtherRights() {
-    testUserMarking(AccessType.DENY, AccessRight.NONE_AS_INT, false,
-        AccessRight.DELETE);
-    testUserMarking(AccessType.DENY, AccessRight.NONE_AS_INT, false,
-        AccessRight.WRITE);
-    testUserMarking(AccessType.DENY, AccessRight.NONE_AS_INT, false,
-        AccessRight.DELETE, AccessRight.WRITE, AccessRight.WRITE_ACL);
-  }
-
-  @SuppressWarnings({"unchecked"})
-  @Test
-  public void testMarking_NoUseRight_HavingBothAllowAndDeny() {
-    User user1 =
-        SecurityPrincipalMocks.createUserWithDomain("user1", "foo.example.com");
-
-    AccessPermissionMock perm1 =
-        new AccessPermissionMock(PermissionSource.SOURCE_DIRECT);
-    perm1.set_AccessType(AccessType.ALLOW);
-    perm1.set_AccessMask(AccessRight.NONE_AS_INT);
-    perm1.set_GranteeType(SecurityPrincipalType.USER);
-    perm1.set_GranteeName(user1.get_Name());
-    perms.add(perm1);
-
-    // The access mask can be set to any value for DENY as it does not have any
-    // effects.
-    AccessPermissionMock perm2 =
-        new AccessPermissionMock(PermissionSource.SOURCE_DIRECT);
-    perm2.set_AccessType(AccessType.DENY);
-    perm2.set_AccessMask(VIEW_ACCESS_RIGHTS);
-    perm2.set_GranteeType(SecurityPrincipalType.USER);
-    perm2.set_GranteeName(user1.get_Name());
-    perms.add(perm2);
-
-    Permissions testPerms = new Permissions(perms);
-    assertEquals(true, testPerms.authorizeMarking(user1,
-        constraintMask(AccessRight.VIEW_CONTENT, AccessRight.READ)));
-  }
-
-  @SuppressWarnings({"unchecked"})
-  @Test
-  public void testMarking_HavingBothAllowAndDenyUseRights() {
-    User user1 =
-        SecurityPrincipalMocks.createUserWithDomain("user1", "foo.example.com");
-
-    AccessPermissionMock allowUse =
-        new AccessPermissionMock(PermissionSource.SOURCE_DIRECT);
-    allowUse.set_AccessType(AccessType.ALLOW);
-    allowUse.set_AccessMask(AccessRight.USE_MARKING_AS_INT);
-    allowUse.set_GranteeType(SecurityPrincipalType.USER);
-    allowUse.set_GranteeName(user1.get_Name());
-    perms.add(allowUse);
-
-    AccessPermissionMock denyUse =
-        new AccessPermissionMock(PermissionSource.SOURCE_DIRECT);
-    denyUse.set_AccessType(AccessType.DENY);
-    denyUse.set_AccessMask(AccessRight.USE_MARKING_AS_INT);
-    denyUse.set_GranteeType(SecurityPrincipalType.USER);
-    denyUse.set_GranteeName(user1.get_Name());
-    perms.add(denyUse);
-
-    Permissions testPerms = new Permissions(perms);
-    assertEquals(false, testPerms.authorizeMarking(user1,
-        constraintMask(AccessRight.NONE_AS_INT)));
-    assertEquals(true, testPerms.authorizeMarking(user1,
-        constraintMask(AccessRight.VIEW_CONTENT, AccessRight.READ)));
-  }
-
-  @Test
-  public void testMarking_UserNotMatchingAnyAces() {
-    User user1 =
-        SecurityPrincipalMocks.createUserWithDomain("user1", "foo.example.com");
-    testMarking(AccessType.ALLOW, VIEW_ACCESS_RIGHTS,
-        SecurityPrincipalType.USER, "user2@bar.example.com", user1, true,
-        AccessRight.READ, AccessRight.VIEW_CONTENT);
-    testMarking(AccessType.ALLOW, VIEW_ACCESS_RIGHTS,
-        SecurityPrincipalType.USER, "user2@bar.example.com", user1, false,
-        AccessRight.NONE);
-  }
-
-  //======================================================================
 
   @SuppressWarnings("deprecation")  // For PermissionSource.MARKING
   @Test


### PR DESCRIPTION
Remove the authz methods from Permissions and its tests.
Also replace use of deprecated AccessLevel in PermissionsTest
with AccessRights.