### PR TITLE
Use a MessageFormat pattern for the display URL

### DIFF
--- a/src/com/google/enterprise/adaptor/filenet/ConfigOptions.java
+++ b/src/com/google/enterprise/adaptor/filenet/ConfigOptions.java
@@ -114,7 +114,7 @@ class ConfigOptions {
       logger.log(Level.CONFIG, "displayUrlPattern: {0}", pattern);
     } catch (IllegalArgumentException | URISyntaxException e) {
       throw new InvalidConfigurationException(
-          "Invalid displayUrlPattern: " + pattern, e);
+          "Invalid displayUrlPattern: " + e.getMessage());
     }
 
     markAllDocsAsPublic =

--- a/src/com/google/enterprise/adaptor/filenet/ConfigOptions.java
+++ b/src/com/google/enterprise/adaptor/filenet/ConfigOptions.java
@@ -195,15 +195,15 @@ class ConfigOptions {
     return objectFactory.getObjectStore(connection, objectStoreName);
   }
 
-  public URI getDisplayUrl(Id objectId, Id versionSeriesId) {
-    return URI.create(getDisplayUrl(displayUrlPattern, objectId,
-        versionSeriesId, objectStoreName));
+  public URI getDisplayUrl(Id guid, Id vsId) {
+    return URI.create(getDisplayUrl(displayUrlPattern, guid,
+        vsId, objectStoreName));
   }
 
   private static String getDisplayUrl(String displayUrlPattern, Id guid,
-      Id versionSeriesId, String objectStoreName) {
+      Id vsId, String objectStoreName) {
     return MessageFormat.format(displayUrlPattern,
-        new Object[] { percentEscape(guid), percentEscape(versionSeriesId),
+        new Object[] { percentEscape(guid), percentEscape(vsId),
             objectStoreName });
   }
 

--- a/src/com/google/enterprise/adaptor/filenet/ConfigOptions.java
+++ b/src/com/google/enterprise/adaptor/filenet/ConfigOptions.java
@@ -14,7 +14,7 @@
 
 package com.google.enterprise.adaptor.filenet;
 
-import static com.google.enterprise.adaptor.filenet.DocumentTraverser.percentEscape;
+import static com.google.enterprise.adaptor.filenet.FileNetAdaptor.percentEscape;
 
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableSet;
@@ -26,7 +26,9 @@ import com.google.enterprise.adaptor.SensitiveValueDecoder;
 import com.filenet.api.core.ObjectStore;
 import com.filenet.api.util.Id;
 
+import java.net.URI;
 import java.net.URISyntaxException;
+import java.text.MessageFormat;
 import java.text.SimpleDateFormat;
 import java.util.Set;
 import java.util.logging.Level;
@@ -47,7 +49,7 @@ class ConfigOptions {
   private final String objectStoreName;
 
   private final ObjectFactory objectFactory;
-  private final String displayUrl;
+  private final String displayUrlPattern;
   private final boolean markAllDocsAsPublic;
   private final String additionalWhereClause;
   private final Set<String> includedMetadata;
@@ -96,26 +98,23 @@ class ConfigOptions {
     logger.log(Level.CONFIG, "filenet.objectFactory: {0}", objectFactoryName);
 
     // TODO(jlacey): Replace this with a MessageFormat pattern.
-    String workplaceUrl = config.getValue("filenet.displayUrl");
-    if (workplaceUrl.endsWith("/getContent/")) {
-      workplaceUrl = workplaceUrl.substring(0, workplaceUrl.length() - 1);
-    }
-    if (workplaceUrl.contains("/getContent")
-        && workplaceUrl.endsWith("/getContent")) {
-      workplaceUrl += "?objectStoreName=" + objectStoreName
-          + "&objectType=document&versionStatus=1&vsId=";
-    } else {
-      workplaceUrl += "/getContent?objectStoreName=" + objectStoreName
-          + "&objectType=document&versionStatus=1&vsId=";
-    }
-    displayUrl = workplaceUrl;
-    logger.log(Level.CONFIG, "displayUrl: {0}", displayUrl);
+    String pattern = config.getValue("filenet.displayUrlPattern");
     try {
-      new ValidatedUri(displayUrl + percentEscape(Id.ZERO_ID.toString()))
+      URI uri = new URI(
+          getDisplayUrl(pattern, Id.ZERO_ID, Id.ZERO_ID, objectStoreName));
+      if (!uri.isAbsolute()) {
+        URI ceUri = new URI(contentEngineUrl);
+        pattern = ceUri.getScheme() + "://" + ceUri.getRawAuthority()
+            + (pattern.startsWith("/") ? "" : "/") + pattern;
+      }
+      new ValidatedUri(
+          getDisplayUrl(pattern, Id.ZERO_ID, Id.ZERO_ID, objectStoreName))
           .logUnreachableHost();
-    } catch (URISyntaxException e) {
+      this.displayUrlPattern = pattern;
+      logger.log(Level.CONFIG, "displayUrlPattern: {0}", pattern);
+    } catch (IllegalArgumentException | URISyntaxException e) {
       throw new InvalidConfigurationException(
-          "Invalid displayUrl: " + e.getMessage());
+          "Invalid displayUrlPattern: " + pattern, e);
     }
 
     markAllDocsAsPublic =
@@ -196,8 +195,16 @@ class ConfigOptions {
     return objectFactory.getObjectStore(connection, objectStoreName);
   }
 
-  public String getDisplayUrl() {
-    return displayUrl;
+  public URI getDisplayUrl(Id objectId, Id versionSeriesId) {
+    return URI.create(getDisplayUrl(displayUrlPattern, objectId,
+        versionSeriesId, objectStoreName));
+  }
+
+  private static String getDisplayUrl(String displayUrlPattern, Id guid,
+      Id versionSeriesId, String objectStoreName) {
+    return MessageFormat.format(displayUrlPattern,
+        new Object[] { percentEscape(guid), percentEscape(versionSeriesId),
+            objectStoreName });
   }
 
   public boolean markAllDocsAsPublic() {

--- a/src/com/google/enterprise/adaptor/filenet/DocumentTraverser.java
+++ b/src/com/google/enterprise/adaptor/filenet/DocumentTraverser.java
@@ -16,6 +16,7 @@ package com.google.enterprise.adaptor.filenet;
 
 import static com.google.common.collect.Sets.union;
 import static com.google.enterprise.adaptor.filenet.FileNetAdaptor.newDocId;
+import static com.google.enterprise.adaptor.filenet.FileNetAdaptor.percentEscape;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.enterprise.adaptor.Acl;
@@ -88,12 +89,6 @@ class DocumentTraverser implements FileNetAdaptor.Traverser {
     this.options = options;
     // Leave room for the continuation URLs.
     this.maxRecords = options.getMaxFeedUrls() - 2;
-  }
-
-  /** Percent escapes the curly braces in an Id string. */
-  @VisibleForTesting
-  static String percentEscape(String id) {
-    return id.replace("{", "%7B").replace("}", "%7D");
   }
 
   @Override
@@ -310,8 +305,7 @@ class DocumentTraverser implements FileNetAdaptor.Traverser {
     }
 
     response.setContentType(document.get_MimeType());
-    response.setDisplayUrl(
-        URI.create(options.getDisplayUrl() + percentEscape(vsId.toString())));
+    response.setDisplayUrl(options.getDisplayUrl(guid, vsId));
     response.setLastModified(document.get_DateLastModified());
 
     setMetadata(document, response);
@@ -372,8 +366,7 @@ class DocumentTraverser implements FileNetAdaptor.Traverser {
           Acl.InheritanceType.AND_BOTH_PERMIT,
           markingPerms.getAllowUsers(), markingPerms.getDenyUsers(),
           markingPerms.getAllowGroups(), markingPerms.getDenyGroups());
-      fragment = SEC_MARKING_POSTFIX
-          + percentEscape(marking.get_Id().toString());
+      fragment = SEC_MARKING_POSTFIX + percentEscape(marking.get_Id());
       logger.log(Level.FINEST, "Create ACL for active marking {0} {1}#{2}: {3}",
           new Object[] {activeMarking.get_PropertyDisplayName(), docId,
               fragment, markingAcl});

--- a/src/com/google/enterprise/adaptor/filenet/FileNetAdaptor.java
+++ b/src/com/google/enterprise/adaptor/filenet/FileNetAdaptor.java
@@ -72,8 +72,8 @@ public class FileNetAdaptor extends AbstractAdaptor {
     config.addKey("filenet.objectStore", null);
     config.addKey("filenet.objectFactory",
         FileNetObjectFactory.class.getName());
-    // DisplayUrl MessageFormat pattern substitutions
-    // {0}: Object GUID
+    // Display URL MessageFormat pattern substitutions
+    // {0}: Document ID
     // {1}: Version Series ID
     // {2}: ObjectStore name
     config.addKey("filenet.displayUrlPattern",

--- a/src/com/google/enterprise/adaptor/filenet/FileNetAdaptor.java
+++ b/src/com/google/enterprise/adaptor/filenet/FileNetAdaptor.java
@@ -59,6 +59,11 @@ public class FileNetAdaptor extends AbstractAdaptor {
     AbstractAdaptor.main(new FileNetAdaptor(), args);
   }
 
+  /** Percent escapes the curly braces in an Id string. */
+  static String percentEscape(Id id) {
+    return id.toString().replace("{", "%7B").replace("}", "%7D");
+  }
+
   @Override
   public void initConfig(Config config) {
     config.addKey("filenet.contentEngineUrl", null);
@@ -67,7 +72,13 @@ public class FileNetAdaptor extends AbstractAdaptor {
     config.addKey("filenet.objectStore", null);
     config.addKey("filenet.objectFactory",
         FileNetObjectFactory.class.getName());
-    config.addKey("filenet.displayUrl", null);
+    // DisplayUrl MessageFormat pattern substitutions
+    // {0}: Object GUID
+    // {1}: Version Series ID
+    // {2}: ObjectStore name
+    config.addKey("filenet.displayUrlPattern",
+        "/WorkplaceXT/getContent?objectStoreName={2}"
+        + "&objectType=document&versionStatus=1&vsId={1}");
     config.addKey("filenet.additionalWhereClause", "");
     config.addKey("filenet.deleteAdditionalWhereClause", "");
     config.addKey("filenet.excludedMetadata", "");

--- a/test/com/google/enterprise/adaptor/filenet/DocumentTraverserTest.java
+++ b/test/com/google/enterprise/adaptor/filenet/DocumentTraverserTest.java
@@ -15,9 +15,9 @@
 package com.google.enterprise.adaptor.filenet;
 
 import static com.google.enterprise.adaptor.Acl.InheritanceType;
-import static com.google.enterprise.adaptor.filenet.DocumentTraverser.percentEscape;
 import static com.google.enterprise.adaptor.filenet.FileNetAdaptor.Checkpoint.getQueryTimeString;
 import static com.google.enterprise.adaptor.filenet.FileNetAdaptor.newDocId;
+import static com.google.enterprise.adaptor.filenet.FileNetAdaptor.percentEscape;
 import static com.google.enterprise.adaptor.filenet.ObjectMocks.mockActiveMarking;
 import static com.google.enterprise.adaptor.filenet.ObjectMocks.mockDocument;
 import static com.google.enterprise.adaptor.filenet.ObjectMocks.mockDocumentNotFound;
@@ -576,7 +576,7 @@ public class DocumentTraverserTest {
   }
 
   private String markingFragment(String id) {
-    return "MARK" + percentEscape(id);
+    return "MARK" + percentEscape(new Id(id));
   }
 
   /**

--- a/test/com/google/enterprise/adaptor/filenet/FileNetAdaptorTest.java
+++ b/test/com/google/enterprise/adaptor/filenet/FileNetAdaptorTest.java
@@ -17,6 +17,7 @@ package com.google.enterprise.adaptor.filenet;
 import static com.google.enterprise.adaptor.DocIdPusher.Record;
 import static com.google.enterprise.adaptor.Principal.DEFAULT_NAMESPACE;
 import static com.google.enterprise.adaptor.filenet.FileNetAdaptor.Checkpoint;
+import static com.google.enterprise.adaptor.filenet.FileNetAdaptor.percentEscape;
 import static org.hamcrest.CoreMatchers.isA;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -76,7 +77,6 @@ public class FileNetAdaptorTest {
     config.overrideKey("filenet.objectStore", "ObjectStore");
     config.overrideKey("filenet.objectFactory",
         FileNetProxies.class.getName());
-    config.overrideKey("filenet.displayUrl", "http://localhost/");
   }
 
   @After
@@ -379,49 +379,57 @@ public class FileNetAdaptorTest {
   }
 
   @Test
-  public void testInit_displayUrl_bare() throws Exception {
-    config.overrideKey("filenet.displayUrl", "http://localhost");
-    config.overrideKey("filenet.objectStore", "ObjectStore");
+  public void testInit_displayUrl_default() throws Exception {
     adaptor.init(context);
-    String expected = "http://localhost/getContent?objectStoreName=ObjectStore"
-        + "&objectType=document&versionStatus=1&vsId=";
-    assertEquals(expected, getConfigOptions().getDisplayUrl());
+    Id guid = new Id("{AAAAAAAA-0000-0000-0000-000000000001}");
+    Id vsId = new Id("{AAAAAAAA-0000-0000-0000-000000000002}");
+    String expected = "http://localhost/WorkplaceXT/getContent"
+        + "?objectStoreName=ObjectStore"
+        + "&objectType=document&versionStatus=1&vsId=" + percentEscape(vsId);
+    assertEquals(expected,
+        getConfigOptions().getDisplayUrl(guid, vsId).toString());
   }
 
   @Test
-  public void testInit_displayUrl_getContent() throws Exception {
-    config.overrideKey("filenet.displayUrl", "http://localhost/getContent");
-    config.overrideKey("filenet.objectStore", "ObjectStore");
+  public void testInit_displayUrl_relative() throws Exception {
+    config.overrideKey("filenet.contentEngineUrl", "https://localhost:8080/");
+    config.overrideKey("filenet.displayUrlPattern", "getContent?os={2}&vs={1}");
     adaptor.init(context);
-    String expected = "http://localhost/getContent?objectStoreName=ObjectStore"
-        + "&objectType=document&versionStatus=1&vsId=";
-    assertEquals(expected, getConfigOptions().getDisplayUrl());
+    Id guid = new Id("{AAAAAAAA-0000-0000-0000-000000000001}");
+    Id vsId = new Id("{AAAAAAAA-0000-0000-0000-000000000002}");
+    String expected = "https://localhost:8080/getContent?os=ObjectStore&vs="
+        + percentEscape(vsId);
+    assertEquals(expected,
+        getConfigOptions().getDisplayUrl(guid, vsId).toString());
   }
 
   @Test
-  public void testInit_displayUrl_getContentSlash() throws Exception {
-    config.overrideKey("filenet.displayUrl", "http://localhost/getContent/");
-    config.overrideKey("filenet.objectStore", "ObjectStore");
+  public void testInit_displayUrl_absolute() throws Exception {
+    config.overrideKey("filenet.displayUrlPattern",
+        "https://localhost:8080/getContent?os=ObjStore&vs={1}&guid={0}");
     adaptor.init(context);
-    String expected = "http://localhost/getContent?objectStoreName=ObjectStore"
-        + "&objectType=document&versionStatus=1&vsId=";
-    assertEquals(expected, getConfigOptions().getDisplayUrl());
+    Id guid = new Id("{AAAAAAAA-0000-0000-0000-000000000001}");
+    Id vsId = new Id("{AAAAAAAA-0000-0000-0000-000000000002}");
+    String expected = "https://localhost:8080/getContent?os=ObjStore&vs="
+        + percentEscape(vsId) + "&guid=" + percentEscape(guid);
+    assertEquals(expected,
+        getConfigOptions().getDisplayUrl(guid, vsId).toString());
   }
 
   @Test
-  public void testInit_displayUrl_invalid() throws Exception {
-    String url = "foo/bar";
-    config.overrideKey("filenet.displayUrl", url);
+  public void testInit_displayUrl_invalidPattern() throws Exception {
+    config.overrideKey("filenet.displayUrlPattern", "{foobar}");
     thrown.expect(InvalidConfigurationException.class);
-    thrown.expectMessage("Invalid displayUrl");
+    thrown.expectMessage("Invalid displayUrlPattern");
     adaptor.init(context);
   }
 
   @Test
-  public void testInit_displayUrl_missing() throws Exception {
-    config.overrideKey("filenet.displayUrl", null);
+  public void testInit_displayUrl_invalidUri() throws Exception {
+    config.overrideKey("filenet.displayUrlPattern",
+        "http://some host/{0};{1};{2};{3}");
     thrown.expect(InvalidConfigurationException.class);
-    thrown.expectMessage("You must set configuration key");
+    thrown.expectMessage("Invalid displayUrlPattern");
     adaptor.init(context);
   }
 

--- a/test/com/google/enterprise/adaptor/filenet/FileNetAdaptorTest.java
+++ b/test/com/google/enterprise/adaptor/filenet/FileNetAdaptorTest.java
@@ -406,11 +406,11 @@ public class FileNetAdaptorTest {
   @Test
   public void testInit_displayUrl_absolute() throws Exception {
     config.overrideKey("filenet.displayUrlPattern",
-        "https://localhost:8080/getContent?os=ObjStore&vs={1}&guid={0}");
+        "https://localhost:8080/whatever?os=NotObjectStore&vs={1}&guid={0}");
     adaptor.init(context);
     Id guid = new Id("{AAAAAAAA-0000-0000-0000-000000000001}");
     Id vsId = new Id("{AAAAAAAA-0000-0000-0000-000000000002}");
-    String expected = "https://localhost:8080/getContent?os=ObjStore&vs="
+    String expected = "https://localhost:8080/whatever?os=NotObjectStore&vs="
         + percentEscape(vsId) + "&guid=" + percentEscape(guid);
     assertEquals(expected,
         getConfigOptions().getDisplayUrl(guid, vsId).toString());


### PR DESCRIPTION
- Change config property name from displayUrl to displayUrlPattern.
- The pattern should be in MessageFormat syntax, with the following
  substitutions allowed:
    {0}: Object GUID
    {1}: Version Series ID
    {2}: ObjectStore name
- Allow the displayUrlPattern to be relative, and use the contentEngineUrl
  scheme and authority.
- Specifies a default displayUrlPattern that is relative, this allows the
  administrator to just specify the contentEngineUrl.
- ConfigOptions.getDisplayUrl() now takes the guid and version series IDs,
  and returns a URI.

Unrelated changes:
- Moved percentEscape into FileNetAdaptor, and changed its param to an Id.