### PR TITLE
Add a default value for filenet.excludedMetadata.

### DIFF
--- a/adaptor-config.properties.sample
+++ b/adaptor-config.properties.sample
@@ -12,7 +12,7 @@ filenet.objectStore =
 
 # Optional properties.
 # filenet.additionalWhereClause =
-# filenet.displayUrl = /WorkplaceXT/getContent?objectStoreName={2}\
+# filenet.displayUrlPattern = /WorkplaceXT/getContent?objectStoreName={2}\
 #     &objectType=document&versionStatus=1&vsId={1}
 # filenet.excludedMetadata = Accessor, ActiveMarkings, CmIndexingFailureCode, \
 #     CmRetentionDate, ComponentBindingLabel, ContentElements, \

--- a/adaptor-config.properties.sample
+++ b/adaptor-config.properties.sample
@@ -9,10 +9,16 @@ filenet.contentEngineUrl =
 filenet.username =
 filenet.password =
 filenet.objectStore =
-filenet.displayUrl  =
 
 # Optional properties.
 # filenet.additionalWhereClause =
-# filenet.deleteAdditionalWhereClause =
-# filenet.excludedMetadata =
+# filenet.displayUrl = /WorkplaceXT/getContent?objectStoreName={2}\
+#     &objectType=document&versionStatus=1&vsId={1}
+# filenet.excludedMetadata = Accessor, ActiveMarkings, CmIndexingFailureCode, \
+#     CmRetentionDate, ComponentBindingLabel, ContentElements, \
+#     ContentRetentionDate, DateContentLastAccessed, EntryTemplateId, \
+#     EntryTemplateLaunchedWorkflowNumber, EntryTemplateObjectStoreName, \
+#     IgnoreRedirect, IsInExceptionState, IsVersioningEnabled, LockOwner, \
+#     Permissions, ReservationType
 # filenet.includedMetadata =
+# filenet.metadataDateFormat = yyyy-MM-dd

--- a/test/com/google/enterprise/adaptor/filenet/FileNetAdaptorTest.java
+++ b/test/com/google/enterprise/adaptor/filenet/FileNetAdaptorTest.java
@@ -484,7 +484,8 @@ public class FileNetAdaptorTest {
   @Test
   public void testInit_excludedMetadata_default() throws Exception {
     adaptor.init(context);
-    assertEquals(ImmutableSet.of(), getConfigOptions().getExcludedMetadata());
+    assertEquals(FileNetAdaptor.excludedMetadata,
+        getConfigOptions().getExcludedMetadata());
   }
 
   @Test


### PR DESCRIPTION
The properties excluded by default are a combination of:
* properties excluded in v3
* similar properties added in more recent versions FileNet of P8
* access-related properties excluded to avoid indexing churn
* Objects that appear in getDocContentPropertyFilter
  (These would not be indexed, since they are all objects, but they
  lead to errors in the connector logs, which is nearly as bad.)

The default value for filenet.includedMetadata is empty by design.

Related changes:

* Add default values of other optional properties to
  adaptor-config.properties.sample.

Other changes:

* Delete the filenet.deleteAdditionalWhereClause property (the related
  code was deleted in commit 889fecc).