### PR TITLE
Add configurable #AUTHENTICATED_USERS group

### DIFF
--- a/src/com/google/enterprise/adaptor/filenet/ConfigOptions.java
+++ b/src/com/google/enterprise/adaptor/filenet/ConfigOptions.java
@@ -55,6 +55,7 @@ class ConfigOptions {
   private final Set<String> includedMetadata;
   private final Set<String> excludedMetadata;
   private final ThreadLocal<SimpleDateFormat> metadataDateFormat;
+  private final String authenticatedUsersGroup;
   private final String globalNamespace;
   private final int maxFeedUrls;
 
@@ -121,6 +122,11 @@ class ConfigOptions {
         Boolean.parseBoolean(config.getValue("adaptor.markAllDocsAsPublic"));
     logger.log(Level.CONFIG, "adaptor.markAllDocsAsPublic: {0}",
         markAllDocsAsPublic);
+
+    authenticatedUsersGroup =
+        config.getValue("filenet.authenticatedUsersGroup");
+    logger.log(Level.CONFIG, "filenet.authenticatedUsersGroup: {0}",
+        authenticatedUsersGroup);
 
     globalNamespace = config.getValue("adaptor.namespace");
     logger.log(Level.CONFIG, "adaptor.namespace: {0}", globalNamespace);
@@ -209,6 +215,10 @@ class ConfigOptions {
 
   public boolean markAllDocsAsPublic() {
     return markAllDocsAsPublic;
+  }
+
+  public String getAuthenticatedUsersGroup() {
+    return authenticatedUsersGroup;
   }
 
   public String getGlobalNamespace() {

--- a/src/com/google/enterprise/adaptor/filenet/DocumentTraverser.java
+++ b/src/com/google/enterprise/adaptor/filenet/DocumentTraverser.java
@@ -63,7 +63,6 @@ import com.filenet.api.util.Id;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.net.URI;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Date;
@@ -510,6 +509,9 @@ class DocumentTraverser implements FileNetAdaptor.Traverser {
       String namespace) {
     ArrayList<GroupPrincipal> list = new ArrayList<>();
     for (String name : names) {
+      if (name.equals(Permissions.AUTHENTICATED_USERS)) {
+        name = options.getAuthenticatedUsersGroup();
+      }
       list.add(new GroupPrincipal(FileUtil.convertDn(name), namespace));
     }
     return list;

--- a/src/com/google/enterprise/adaptor/filenet/FileNetAdaptor.java
+++ b/src/com/google/enterprise/adaptor/filenet/FileNetAdaptor.java
@@ -116,6 +116,8 @@ public class FileNetAdaptor extends AbstractAdaptor {
         Joiner.on(',').join(excludedMetadata));
     config.addKey("filenet.includedMetadata", "");
     config.addKey("filenet.metadataDateFormat", "yyyy-MM-dd");
+    config.addKey("filenet.authenticatedUsersGroup",
+        "NT AUTHORITY\\Authenticated Users");
     config.addKey("adaptor.namespace", DEFAULT_NAMESPACE);
   }
 

--- a/src/com/google/enterprise/adaptor/filenet/Permissions.java
+++ b/src/com/google/enterprise/adaptor/filenet/Permissions.java
@@ -101,8 +101,6 @@ class Permissions {
     boolean authorizeByConstraints =
         (VIEW_ACCESS_RIGHTS & ~constraintMask) == VIEW_ACCESS_RIGHTS;
     if (authorizeByConstraints) {
-      // TODO(bmj): AUTHENTICATED_USERS should really be feed as a local
-      // group, not a global group.
       allowGroups.put(PermissionSource.MARKING, AUTHENTICATED_USERS);
     } else {
       // If we added a denyGroups of AUTHENTICATED_USERS, the ACL would

--- a/test/com/google/enterprise/adaptor/filenet/DocumentTraverserTest.java
+++ b/test/com/google/enterprise/adaptor/filenet/DocumentTraverserTest.java
@@ -609,7 +609,7 @@ public class DocumentTraverserTest {
         TestObjectFactory.newPermissionList(ImmutableList.of(
             TestObjectFactory.newPermission(Permissions.AUTHENTICATED_USERS,
                 SecurityPrincipalType.GROUP, AccessType.ALLOW,
-                (AccessRight.READ_AS_INT | AccessRight.VIEW_CONTENT_AS_INT),
+                Permissions.VIEW_ACCESS_RIGHTS,
                 0, PermissionSource.SOURCE_DIRECT))));
 
     DocumentTraverser traverser = new DocumentTraverser(options);

--- a/test/com/google/enterprise/adaptor/filenet/DocumentTraverserTest.java
+++ b/test/com/google/enterprise/adaptor/filenet/DocumentTraverserTest.java
@@ -44,6 +44,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.enterprise.adaptor.Acl;
 import com.google.enterprise.adaptor.DocId;
 import com.google.enterprise.adaptor.DocIdPusher.Record;
+import com.google.enterprise.adaptor.GroupPrincipal;
 import com.google.enterprise.adaptor.Metadata;
 import com.google.enterprise.adaptor.Request;
 import com.google.enterprise.adaptor.filenet.EngineCollectionMocks.AccessPermissionListMock;
@@ -61,8 +62,10 @@ import com.google.enterprise.adaptor.testing.RecordingResponse;
 
 import com.filenet.api.constants.AccessLevel;
 import com.filenet.api.constants.AccessRight;
+import com.filenet.api.constants.AccessType;
 import com.filenet.api.constants.PermissionSource;
 import com.filenet.api.constants.PropertyNames;
+import com.filenet.api.constants.SecurityPrincipalType;
 import com.filenet.api.property.FilterElement;
 import com.filenet.api.property.Property;
 import com.filenet.api.property.PropertyBinaryList;
@@ -582,6 +585,50 @@ public class DocumentTraverserTest {
         response.getMetadata());
   }
 
+  @Test
+  public void testGetDocContent_defaultAuthenticatedUsers() throws Exception {
+    testGetDocContent_authenticatedUsers("NT AUTHORITY\\Authenticated Users");
+  }
+
+  @Test
+  public void testGetDocContent_customAuthenticatedUsers() throws Exception {
+    options = TestObjectFactory.newConfigOptions(
+        ImmutableMap.<String, String>of(
+            "filenet.authenticatedUsersGroup",
+            "cn=AuthenticatedUsers,ou=users,dc=example,dc=com"));
+
+    testGetDocContent_authenticatedUsers("AuthenticatedUsers@example.com");
+  }
+
+  private void testGetDocContent_authenticatedUsers(String authenticatedUsers)
+      throws Exception {
+    String id = "{AAAAAAAA-0000-0000-0000-000000000000}";
+    DocId docId = newDocId(new Id(id));
+    MockObjectStore os = getObjectStore();
+    mockDocument(os, id, DOCUMENT_TIMESTAMP, RELEASED, 42d, "text/plain",
+        TestObjectFactory.newPermissionList(ImmutableList.of(
+            TestObjectFactory.newPermission(Permissions.AUTHENTICATED_USERS,
+                SecurityPrincipalType.GROUP, AccessType.ALLOW,
+                (AccessRight.READ_AS_INT | AccessRight.VIEW_CONTENT_AS_INT),
+                0, PermissionSource.SOURCE_DIRECT))));
+
+    DocumentTraverser traverser = new DocumentTraverser(options);
+    Request request = new MockRequest(docId);
+    RecordingResponse response = new RecordingResponse();
+    traverser.getDocContent(new Id(id), request, response);
+
+    Acl acl = response.getAcl();
+    assertEquals(acl.getPermitGroups().toString(),
+        ImmutableSet.<GroupPrincipal>of(new GroupPrincipal(authenticatedUsers,
+            options.getGlobalNamespace())),
+        acl.getPermitGroups());
+    assertTrue(acl.getPermitUsers().toString(),
+        acl.getPermitUsers().isEmpty());
+    assertTrue(acl.getDenyGroups().toString(),
+        acl.getDenyGroups().isEmpty());
+    assertTrue(acl.getDenyUsers().toString(),
+        acl.getDenyUsers().isEmpty());
+  }
 
   @Test
   public void testGetDocContent_markAllDocsPublic() throws Exception {

--- a/test/com/google/enterprise/adaptor/filenet/DocumentTraverserTest.java
+++ b/test/com/google/enterprise/adaptor/filenet/DocumentTraverserTest.java
@@ -593,7 +593,7 @@ public class DocumentTraverserTest {
   @Test
   public void testGetDocContent_customAuthenticatedUsers() throws Exception {
     options = TestObjectFactory.newConfigOptions(
-        ImmutableMap.<String, String>of(
+        ImmutableMap.of(
             "filenet.authenticatedUsersGroup",
             "cn=AuthenticatedUsers,ou=users,dc=example,dc=com"));
 
@@ -618,9 +618,8 @@ public class DocumentTraverserTest {
     traverser.getDocContent(new Id(id), request, response);
 
     Acl acl = response.getAcl();
-    assertEquals(acl.getPermitGroups().toString(),
-        ImmutableSet.<GroupPrincipal>of(new GroupPrincipal(authenticatedUsers,
-            options.getGlobalNamespace())),
+    assertEquals(ImmutableSet.of(
+        new GroupPrincipal(authenticatedUsers, options.getGlobalNamespace())),
         acl.getPermitGroups());
     assertTrue(acl.getPermitUsers().toString(),
         acl.getPermitUsers().isEmpty());

--- a/test/com/google/enterprise/adaptor/filenet/PermissionsTest.java
+++ b/test/com/google/enterprise/adaptor/filenet/PermissionsTest.java
@@ -83,15 +83,10 @@ public class PermissionsTest {
 
   @SuppressWarnings({"unchecked"})
   private void addAce(PermissionSource permSrc,
-      SecurityPrincipalType secPrincipalType, AccessType accessType,
-      int accessMask, int inheritableDepth, String ace) {
-    AccessPermissionMock perm = new AccessPermissionMock(permSrc);
-    perm.set_GranteeType(secPrincipalType);
-    perm.set_AccessType(accessType);
-    perm.set_AccessMask(accessMask);
-    perm.set_InheritableDepth(inheritableDepth);
-    perm.set_GranteeName(ace);
-    perms.add(perm);
+      SecurityPrincipalType principalType, AccessType accessType,
+      int accessMask, int inheritableDepth, String granteeName) {
+    perms.add(TestObjectFactory.newPermission(granteeName, principalType,
+        accessType, accessMask, inheritableDepth, permSrc));
   }
 
   private void addAces(int numOfAces, AccessType accessType,

--- a/test/com/google/enterprise/adaptor/filenet/TestObjectFactory.java
+++ b/test/com/google/enterprise/adaptor/filenet/TestObjectFactory.java
@@ -75,7 +75,7 @@ class TestObjectFactory {
 
   // TODO(tdnguyen): Combine this method with similar methods in
   // PermissionsTest.
-  private static AccessPermission newPermission(String granteeName,
+  public static AccessPermission newPermission(String granteeName,
       SecurityPrincipalType principalType, AccessType accessType,
       int accessMask, int inheritableDepth, PermissionSource permSrc) {
     AccessPermissionMock perm = new AccessPermissionMock(permSrc);

--- a/test/com/google/enterprise/adaptor/filenet/TestObjectFactory.java
+++ b/test/com/google/enterprise/adaptor/filenet/TestObjectFactory.java
@@ -67,14 +67,12 @@ class TestObjectFactory {
     List<AccessPermission> aces = new ArrayList<>();
     for (PermissionSource source : sources) {
       aces.addAll(generatePermissions(
-        1, 1, 1, 1, (AccessRight.READ_AS_INT | AccessRight.VIEW_CONTENT_AS_INT),
+        1, 1, 1, 1, Permissions.VIEW_ACCESS_RIGHTS,
         0, source));
     }
     return newPermissionList(aces);
   }
 
-  // TODO(tdnguyen): Combine this method with similar methods in
-  // PermissionsTest.
   public static AccessPermission newPermission(String granteeName,
       SecurityPrincipalType principalType, AccessType accessType,
       int accessMask, int inheritableDepth, PermissionSource permSrc) {


### PR DESCRIPTION
New config property, filenet.authenticatedUsersGroup, specifies
a directory group name to map the FileNet special group
The default value is "NT AUTHORITY\Authenticated Users".