### PR TITLE
Java 9 compatibility.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -47,6 +47,12 @@
   <property name="compile.java.newerClassname"
     value="java.lang.FunctionalInterface"/>
 
+  <!-- Use add-modules with Java 9 and higher. -->
+  <condition property="java.modules"
+      value="" else="--add-modules java.xml.bind">
+    <matches string="${ant.java.version}" pattern="^1\.[678]$"/>
+  </condition>
+
   <path id="adaptor.build.classpath">
     <pathelement location="${adaptor.jar}"/>
     <pathelement location="${filenet.jarfile}"/>
@@ -274,6 +280,7 @@ lib/plexi submodule or add the the command line argument
 
   <target name="run" depends="build" description="Run adaptor">
     <java classpath="${build-src.dir}" fork="true" classname="${adaptor.class}">
+      <jvmarg line="${java.modules}"/>
       <classpath refid="adaptor.run.classpath"/>
       <sysproperty key="java.util.logging.config.file"
         value="logging.properties"/>

--- a/src/com/google/enterprise/adaptor/filenet/ConfigOptions.java
+++ b/src/com/google/enterprise/adaptor/filenet/ConfigOptions.java
@@ -26,6 +26,7 @@ import com.google.enterprise.adaptor.SensitiveValueDecoder;
 import com.filenet.api.core.ObjectStore;
 import com.filenet.api.util.Id;
 
+import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.text.MessageFormat;
@@ -88,12 +89,16 @@ class ConfigOptions {
           "filenet.objectFactory may not be empty");
     }
     try {
-      objectFactory =
-          (ObjectFactory) Class.forName(objectFactoryName).newInstance();
+      objectFactory = (ObjectFactory) Class.forName(objectFactoryName)
+          .getDeclaredConstructor().newInstance();
     } catch (ClassNotFoundException | InstantiationException
-             | IllegalAccessException e) {
+             | IllegalAccessException | NoSuchMethodException e) {
       throw new InvalidConfigurationException(
           "Unable to instantiate object factory: " + objectFactoryName, e);
+    } catch (InvocationTargetException e) {
+      throw new InvalidConfigurationException(
+          "Unable to instantiate object factory: " + objectFactoryName,
+          e.getCause());
     }
     logger.log(Level.CONFIG, "filenet.objectFactory: {0}", objectFactoryName);
 


### PR DESCRIPTION
Deprecated features:

* Class.newInstance (use Constructor.newInstance)

Java EE features:

* Add --add-modules java.xml.bind; also requires Ant 1.9.4 or later